### PR TITLE
#2 카카오 로그인, JWT 토큰 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	//Webflux
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,11 @@ dependencies {
 
 	//Webflux
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+	//Jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/temp/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/temp/common/config/SecurityConfig.java
@@ -1,0 +1,69 @@
+package com.example.temp.common.config;
+
+import com.example.temp.common.exception.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import java.io.PrintWriter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        http
+                .csrf((csrfConfig) ->
+                        csrfConfig.disable()
+                )
+                .headers((headerConfig) ->
+                        headerConfig.frameOptions(frameOptionsConfig ->
+                                frameOptionsConfig.disable()
+                        )
+                )
+                .authorizeHttpRequests((authorizeRequests) ->
+                        authorizeRequests
+                                .requestMatchers(PathRequest.toH2Console()).permitAll()
+                                .requestMatchers("/**").permitAll()
+                                .anyRequest().authenticated()
+                )
+                .exceptionHandling((exceptionConfig) ->
+                        exceptionConfig.authenticationEntryPoint(unauthorizedEntryPoint).accessDeniedHandler(accessDeniedHandler)
+                ); // 401 403 관련 예외처리
+
+        return http.build();
+    }
+
+    private final AuthenticationEntryPoint unauthorizedEntryPoint =
+            (request, response, authException) -> {
+                ErrorResponse fail = new ErrorResponse(HttpStatus.UNAUTHORIZED, "Spring security unauthorized...");
+                response.setStatus(HttpStatus.UNAUTHORIZED.value());
+                String json = new ObjectMapper().writeValueAsString(fail);
+                response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                PrintWriter writer = response.getWriter();
+                writer.write(json);
+                writer.flush();
+            };
+
+    private final AccessDeniedHandler accessDeniedHandler =
+            (request, response, accessDeniedException) -> {
+                ErrorResponse fail = new ErrorResponse(HttpStatus.FORBIDDEN, "Spring security forbidden...");
+                response.setStatus(HttpStatus.FORBIDDEN.value());
+                String json = new ObjectMapper().writeValueAsString(fail);
+                response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                PrintWriter writer = response.getWriter();
+                writer.write(json);
+                writer.flush();
+            };
+
+}

--- a/src/main/java/com/example/temp/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/temp/common/config/SecurityConfig.java
@@ -28,8 +28,7 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
         http
-                .csrf(AbstractHttpConfigurer::disable
-                )
+                .csrf(AbstractHttpConfigurer::disable)
                 .headers((headerConfig) ->
                         headerConfig.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable
                         )

--- a/src/main/java/com/example/temp/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/temp/common/config/SecurityConfig.java
@@ -45,6 +45,7 @@ public class SecurityConfig {
                 ); // 401 403 관련 예외처리
 
         // Jwt 인가 관련 필터
+        // TODO JWT 인가 exception 커스텀
         http.addFilterBefore(new JwtAuthenticationFilter(jwtTokenService), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/src/main/java/com/example/temp/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/temp/common/config/SecurityConfig.java
@@ -1,19 +1,15 @@
 package com.example.temp.common.config;
 
-import com.example.temp.common.exception.ErrorResponse;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.example.temp.common.exception.CustomException;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.AccessDeniedHandler;
-
-import java.io.PrintWriter;
 
 @Configuration
 @EnableWebSecurity
@@ -46,24 +42,12 @@ public class SecurityConfig {
 
     private final AuthenticationEntryPoint unauthorizedEntryPoint =
             (request, response, authException) -> {
-                ErrorResponse fail = new ErrorResponse(HttpStatus.UNAUTHORIZED, "Spring security unauthorized...");
-                response.setStatus(HttpStatus.UNAUTHORIZED.value());
-                String json = new ObjectMapper().writeValueAsString(fail);
-                response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-                PrintWriter writer = response.getWriter();
-                writer.write(json);
-                writer.flush();
+                throw new CustomException(HttpStatus.UNAUTHORIZED, "Spring security unauthorized...");
             };
 
     private final AccessDeniedHandler accessDeniedHandler =
             (request, response, accessDeniedException) -> {
-                ErrorResponse fail = new ErrorResponse(HttpStatus.FORBIDDEN, "Spring security forbidden...");
-                response.setStatus(HttpStatus.FORBIDDEN.value());
-                String json = new ObjectMapper().writeValueAsString(fail);
-                response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-                PrintWriter writer = response.getWriter();
-                writer.write(json);
-                writer.flush();
+                throw new CustomException(HttpStatus.FORBIDDEN, "Spring security forbidden...");
             };
 
 }

--- a/src/main/java/com/example/temp/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/temp/common/config/SecurityConfig.java
@@ -36,8 +36,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests((authorizeRequests) ->
                         authorizeRequests
                                 .requestMatchers(PathRequest.toH2Console()).permitAll()
-                                .requestMatchers("/**").permitAll()
-                                .anyRequest().authenticated()
+                                .requestMatchers("/user/**").authenticated()
+                                .anyRequest().permitAll()
                 )
                 .exceptionHandling((exceptionConfig) ->
                         exceptionConfig.authenticationEntryPoint(unauthorizedEntryPoint).accessDeniedHandler(accessDeniedHandler)

--- a/src/main/java/com/example/temp/common/entity/CustomUserDetails.java
+++ b/src/main/java/com/example/temp/common/entity/CustomUserDetails.java
@@ -1,0 +1,59 @@
+package com.example.temp.common.entity;
+
+import com.example.temp.user.domain.User;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class CustomUserDetails implements UserDetails {
+    private final User user;
+
+    public static UserDetails create(User user) {
+        return new CustomUserDetails(user);
+    }
+
+    public long getId() {
+        return this.user.getId();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public String getPassword() {
+        return "";
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return UserDetails.super.isEnabled();
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return UserDetails.super.isCredentialsNonExpired();
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return UserDetails.super.isAccountNonLocked();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return UserDetails.super.isAccountNonExpired();
+    }
+
+}

--- a/src/main/java/com/example/temp/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/temp/common/exception/GlobalExceptionHandler.java
@@ -68,7 +68,7 @@ public class GlobalExceptionHandler {
 		StringWriter errors = new StringWriter();
 		e.printStackTrace(new PrintWriter(errors));
 		log.error(errors.toString());
-		ErrorResponse errorResponse = new ErrorResponse("예상치 못한 오류 발생");
+		ErrorResponse errorResponse = new ErrorResponse(e.getMessage());
 		return ResponseEntity.badRequest().body(errorResponse);
 	}
 

--- a/src/main/java/com/example/temp/common/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/temp/common/filter/JwtAuthenticationFilter.java
@@ -35,8 +35,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             String token = authorizationHeader.substring(7);
             //JWT 유효성 검증
             if (jwtTokenService.isTokenValid(token)) {
-                String email = jwtTokenService.extractEmail(token);
-
                 //현재 Request의 Security Context에 접근권한 설정
                 Authentication authentication = jwtTokenService.getAuthentication(token);
                 SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/src/main/java/com/example/temp/common/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/temp/common/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,48 @@
+package com.example.temp.common.filter;
+
+import com.example.temp.user.service.impl.JwtTokenService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenService jwtTokenService;
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    /**
+     * JWT 토큰 검증 필터 수행
+     */
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String authorizationHeader = request.getHeader(AUTHORIZATION_HEADER);
+
+        // JWT가 헤더에 있는 경우
+        if (authorizationHeader != null && authorizationHeader.startsWith(BEARER_PREFIX)) {
+            String token = authorizationHeader.substring(7);
+            //JWT 유효성 검증
+            if (jwtTokenService.isTokenValid(token)) {
+                String email = jwtTokenService.extractEmail(token);
+
+                //현재 Request의 Security Context에 접근권한 설정
+                Authentication authentication = jwtTokenService.getAuthentication(token);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/example/temp/user/controller/OAuthController.java
+++ b/src/main/java/com/example/temp/user/controller/OAuthController.java
@@ -1,0 +1,36 @@
+package com.example.temp.user.controller;
+
+import com.example.temp.common.CustomUserDetails;
+import com.example.temp.user.service.impl.OAuthService;
+import com.example.temp.user.service.oauth.response.OAuthResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class OAuthController {
+    private final OAuthService oAuthService;
+
+    @GetMapping("/{platform}/login")
+    public ResponseEntity<String> loginform(
+            @PathVariable("platform") String platform,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        String loginPage = oAuthService.loginPage(platform);
+        return ResponseEntity.ok(loginPage);
+    }
+
+    @GetMapping("/{platform}/login/redirect")
+    public ResponseEntity<OAuthResponse> login(
+            @PathVariable("platform") String platform,
+            @RequestParam("code") String code
+    ) {
+        OAuthResponse profileResponse = oAuthService.login(platform, code);
+        return ResponseEntity.ok(profileResponse);
+    }
+}

--- a/src/main/java/com/example/temp/user/controller/OAuthController.java
+++ b/src/main/java/com/example/temp/user/controller/OAuthController.java
@@ -21,8 +21,7 @@ public class OAuthController {
 
     @GetMapping("/{platformType}/login")
     public ResponseEntity<String> loginform(
-            @PathVariable("platformType") String platformType,
-            @AuthenticationPrincipal CustomUserDetails userDetails
+            @PathVariable("platformType") String platformType
     ) {
         String loginPage = oAuthService.loginPage(platformType);
         return ResponseEntity.ok(loginPage);

--- a/src/main/java/com/example/temp/user/controller/OAuthController.java
+++ b/src/main/java/com/example/temp/user/controller/OAuthController.java
@@ -1,6 +1,8 @@
 package com.example.temp.user.controller;
 
 import com.example.temp.common.CustomUserDetails;
+import com.example.temp.user.dto.AuthLoginResponse;
+import com.example.temp.user.service.CreateUserService;
 import com.example.temp.user.service.impl.OAuthService;
 import com.example.temp.user.service.oauth.response.OAuthResponse;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/auth")
 public class OAuthController {
     private final OAuthService oAuthService;
+    private final CreateUserService createUserService;
 
     @GetMapping("/{platform}/login")
     public ResponseEntity<String> loginform(
@@ -25,12 +28,13 @@ public class OAuthController {
         return ResponseEntity.ok(loginPage);
     }
 
-    @GetMapping("/{platform}/login/redirect")
-    public ResponseEntity<OAuthResponse> login(
-            @PathVariable("platform") String platform,
+    @GetMapping("/{platformType}/login/redirect")
+    public ResponseEntity<AuthLoginResponse> login(
+            @PathVariable("platformType") String platformType,
             @RequestParam("code") String code
     ) {
-        OAuthResponse profileResponse = oAuthService.login(platform, code);
-        return ResponseEntity.ok(profileResponse);
+        OAuthResponse profileResponse = oAuthService.login(platformType, code);
+        AuthLoginResponse authLoginResponse = createUserService.doService(profileResponse);
+        return ResponseEntity.ok(authLoginResponse);
     }
 }

--- a/src/main/java/com/example/temp/user/controller/OAuthController.java
+++ b/src/main/java/com/example/temp/user/controller/OAuthController.java
@@ -19,12 +19,12 @@ public class OAuthController {
     private final OAuthService oAuthService;
     private final CreateUserService createUserService;
 
-    @GetMapping("/{platform}/login")
+    @GetMapping("/{platformType}/login")
     public ResponseEntity<String> loginform(
-            @PathVariable("platform") String platform,
+            @PathVariable("platformType") String platformType,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        String loginPage = oAuthService.loginPage(platform);
+        String loginPage = oAuthService.loginPage(platformType);
         return ResponseEntity.ok(loginPage);
     }
 

--- a/src/main/java/com/example/temp/user/controller/UserController.java
+++ b/src/main/java/com/example/temp/user/controller/UserController.java
@@ -1,6 +1,6 @@
 package com.example.temp.user.controller;
 
-import com.example.temp.user.domain.User;
+import com.example.temp.common.entity.CustomUserDetails;
 import com.example.temp.user.dto.UserProfileView;
 import com.example.temp.user.service.FindUserProfileService;
 import lombok.RequiredArgsConstructor;
@@ -18,8 +18,8 @@ public class UserController {
     private final FindUserProfileService findUserProfileService;
 
     @GetMapping("/profile")
-    public ResponseEntity<UserProfileView> findProfile(@AuthenticationPrincipal User user) {
-        UserProfileView response = findUserProfileService.doService(user.getEmail());
+    public ResponseEntity<UserProfileView> findProfile(@AuthenticationPrincipal CustomUserDetails authenticatedUser) {
+        UserProfileView response = findUserProfileService.doService(authenticatedUser.getId());
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/example/temp/user/controller/UserController.java
+++ b/src/main/java/com/example/temp/user/controller/UserController.java
@@ -1,14 +1,14 @@
 package com.example.temp.user.controller;
 
 import com.example.temp.common.entity.CustomUserDetails;
+import com.example.temp.user.dto.UpdatedUserProfileRequest;
 import com.example.temp.user.dto.UserProfileView;
 import com.example.temp.user.service.FindUserProfileService;
+import com.example.temp.user.service.UpdateUserProfileService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -16,10 +16,20 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     private final FindUserProfileService findUserProfileService;
+    private final UpdateUserProfileService updateUserProfileService;
 
     @GetMapping("/profile")
     public ResponseEntity<UserProfileView> findProfile(@AuthenticationPrincipal CustomUserDetails authenticatedUser) {
         UserProfileView response = findUserProfileService.doService(authenticatedUser.getId());
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/profile")
+    public ResponseEntity<UserProfileView> updateProfile(
+            @AuthenticationPrincipal CustomUserDetails authenticatedUser,
+            @RequestBody UpdatedUserProfileRequest userProfile
+    ) {
+        UserProfileView response = updateUserProfileService.doService(authenticatedUser.getId(), userProfile);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/example/temp/user/controller/UserController.java
+++ b/src/main/java/com/example/temp/user/controller/UserController.java
@@ -1,28 +1,26 @@
 package com.example.temp.user.controller;
 
+import com.example.temp.user.domain.User;
+import com.example.temp.user.dto.UserProfileView;
+import com.example.temp.user.service.FindUserProfileService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.example.temp.common.CustomUserDetails;
-import com.example.temp.user.dto.UserProfileView;
-import com.example.temp.user.service.FindUserProfileService;
-
-import lombok.RequiredArgsConstructor;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/user")
 public class UserController {
 
-	private final FindUserProfileService findUserProfileService;
+    private final FindUserProfileService findUserProfileService;
 
-	@GetMapping("/profile")
-	public ResponseEntity<UserProfileView> findProfile(@AuthenticationPrincipal CustomUserDetails userDetails) {
-		UserProfileView response = findUserProfileService.doService(userDetails.getId());
-		return ResponseEntity.ok(response);
-	}
+    @GetMapping("/profile")
+    public ResponseEntity<UserProfileView> findProfile(@AuthenticationPrincipal User user) {
+        UserProfileView response = findUserProfileService.doService(user.getEmail());
+        return ResponseEntity.ok(response);
+    }
 
 }

--- a/src/main/java/com/example/temp/user/domain/User.java
+++ b/src/main/java/com/example/temp/user/domain/User.java
@@ -5,6 +5,7 @@ import com.example.temp.common.util.IdUtil;
 import com.example.temp.user.domain.value.Nickname;
 import com.example.temp.user.domain.value.PlatformType;
 import com.example.temp.user.domain.value.UserRole;
+import com.example.temp.user.dto.UpdatedUserProfileRequest;
 import com.example.temp.user.service.oauth.response.OAuthResponse;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -27,6 +28,8 @@ public class User extends BaseTimeEntity {
     private String profileImageUrl;
     @Enumerated(EnumType.STRING)
     private UserRole userRole;
+    private Long favoriteTeam;
+    private String oneLiner; // 한 줄 소개
 
     public static User build(OAuthResponse response) {
         User user = new User();
@@ -46,9 +49,11 @@ public class User extends BaseTimeEntity {
         return nickname.getValue();
     }
 
-    public void updateProfile(String name, String profileImageUrl) {
-        this.name = name;
-        this.profileImageUrl = profileImageUrl;
+    public void updateProfile(UpdatedUserProfileRequest request) {
+        this.nickname = new Nickname(request.getNickname());
+        this.oneLiner = request.getOneLiner();
+        this.favoriteTeam = request.getFavoriteTeam();
+        this.profileImageUrl = request.getProfileImageUrl();
     }
 
 }

--- a/src/main/java/com/example/temp/user/domain/User.java
+++ b/src/main/java/com/example/temp/user/domain/User.java
@@ -37,9 +37,9 @@ public class User extends BaseTimeEntity {
         user.platformId = response.getPlatformId();
         user.platformType = response.getPlatformType();
         user.email = response.getEmail();
-        user.name = response.getNickname();
+        user.name = response.getName();
         // TODO nickname 정책 확인
-        user.nickname = new Nickname("temp");
+        user.nickname = new Nickname(response.getName());
         user.profileImageUrl = response.getProfileImageUrl();
         user.userRole = UserRole.USER;
         return user;

--- a/src/main/java/com/example/temp/user/domain/User.java
+++ b/src/main/java/com/example/temp/user/domain/User.java
@@ -3,6 +3,8 @@ package com.example.temp.user.domain;
 import com.example.temp.common.entity.BaseTimeEntity;
 import com.example.temp.common.util.IdUtil;
 import com.example.temp.user.domain.value.Nickname;
+import com.example.temp.user.domain.value.PlatformType;
+import com.example.temp.user.domain.value.UserRole;
 import com.example.temp.user.service.oauth.response.OAuthResponse;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -23,7 +25,7 @@ public class User extends BaseTimeEntity implements UserDetails {
     @Id
     private Long id;
     private Long platformId;
-    private String platformType;
+    private PlatformType platformType;
     private String email;
     private String name;
     @Embedded

--- a/src/main/java/com/example/temp/user/domain/User.java
+++ b/src/main/java/com/example/temp/user/domain/User.java
@@ -3,33 +3,89 @@ package com.example.temp.user.domain;
 import com.example.temp.common.entity.BaseTimeEntity;
 import com.example.temp.common.util.IdUtil;
 import com.example.temp.user.domain.value.Nickname;
-
+import com.example.temp.user.service.oauth.response.OAuthResponse;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
 
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class User extends BaseTimeEntity {
-
+public class User extends BaseTimeEntity implements UserDetails {
     @Id
     private Long id;
-
+    private Long platformId;
+    private String platformType;
+    private String email;
+    private String name;
     @Embedded
     private Nickname nickname;
+    private String profileImageUrl;
+    private UserRole userRole;
 
-    public static User build(Nickname nickname) {
+    public static User build(OAuthResponse response) {
         User user = new User();
         user.id = IdUtil.create();
-        user.nickname = nickname;
+        user.platformId = response.getPlatformId();
+        user.platformType = response.getPlatformType();
+        user.email = response.getEmail();
+        user.name = response.getName();
+        // TODO nickname 정책 확인
+        user.nickname = new Nickname("temp");
+        user.profileImageUrl = response.getProfileImageUrl();
+        user.userRole = UserRole.USER;
         return user;
     }
 
     public String getNickname() {
         return nickname.getValue();
+    }
+
+    public void updateProfile(String name, String profileImageUrl) {
+        this.name = name;
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    @Override
+    public String getUsername() {
+        return this.name;
+    }
+
+    @Override
+    public String getPassword() {
+        return this.email;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
     }
 }

--- a/src/main/java/com/example/temp/user/domain/User.java
+++ b/src/main/java/com/example/temp/user/domain/User.java
@@ -39,7 +39,7 @@ public class User extends BaseTimeEntity implements UserDetails {
         user.platformId = response.getPlatformId();
         user.platformType = response.getPlatformType();
         user.email = response.getEmail();
-        user.name = response.getName();
+        user.name = response.getNickname();
         // TODO nickname 정책 확인
         user.nickname = new Nickname("temp");
         user.profileImageUrl = response.getProfileImageUrl();

--- a/src/main/java/com/example/temp/user/domain/User.java
+++ b/src/main/java/com/example/temp/user/domain/User.java
@@ -6,31 +6,26 @@ import com.example.temp.user.domain.value.Nickname;
 import com.example.temp.user.domain.value.PlatformType;
 import com.example.temp.user.domain.value.UserRole;
 import com.example.temp.user.service.oauth.response.OAuthResponse;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails;
-
-import java.util.Collection;
-import java.util.List;
 
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class User extends BaseTimeEntity implements UserDetails {
+public class User extends BaseTimeEntity {
     @Id
     private Long id;
     private Long platformId;
+    @Enumerated(EnumType.STRING)
     private PlatformType platformType;
     private String email;
     private String name;
     @Embedded
     private Nickname nickname;
     private String profileImageUrl;
+    @Enumerated(EnumType.STRING)
     private UserRole userRole;
 
     public static User build(OAuthResponse response) {
@@ -56,38 +51,4 @@ public class User extends BaseTimeEntity implements UserDetails {
         this.profileImageUrl = profileImageUrl;
     }
 
-    @Override
-    public String getUsername() {
-        return this.email;
-    }
-
-    @Override
-    public String getPassword() {
-        return this.email;
-    }
-
-    @Override
-    public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of();
-    }
-
-    @Override
-    public boolean isEnabled() {
-        return true;
-    }
-
-    @Override
-    public boolean isCredentialsNonExpired() {
-        return true;
-    }
-
-    @Override
-    public boolean isAccountNonLocked() {
-        return true;
-    }
-
-    @Override
-    public boolean isAccountNonExpired() {
-        return true;
-    }
 }

--- a/src/main/java/com/example/temp/user/domain/User.java
+++ b/src/main/java/com/example/temp/user/domain/User.java
@@ -56,7 +56,7 @@ public class User extends BaseTimeEntity implements UserDetails {
 
     @Override
     public String getUsername() {
-        return this.name;
+        return this.email;
     }
 
     @Override

--- a/src/main/java/com/example/temp/user/domain/UserRepository.java
+++ b/src/main/java/com/example/temp/user/domain/UserRepository.java
@@ -13,7 +13,7 @@ public interface UserRepository extends Repository<User, Long> {
 	Optional<User> findByEmail(String email);
 	User save(User saveUser);
 
-	default User findByIdOrElseThrow(Long id) {
-		return findById(id).orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "회원 조회 실패"));
+	default User findByIdOrElseThrow(String email) {
+		return findByEmail(email).orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "회원 조회 실패"));
 	}
 }

--- a/src/main/java/com/example/temp/user/domain/UserRepository.java
+++ b/src/main/java/com/example/temp/user/domain/UserRepository.java
@@ -1,19 +1,27 @@
 package com.example.temp.user.domain;
 
-import java.util.Optional;
-
+import com.example.temp.common.exception.CustomException;
 import org.springframework.data.repository.Repository;
 import org.springframework.http.HttpStatus;
 
-import com.example.temp.common.exception.CustomException;
+import java.util.Optional;
 
 public interface UserRepository extends Repository<User, Long> {
 
-	Optional<User> findById(Long id);
-	Optional<User> findByEmail(String email);
-	User save(User saveUser);
+    Optional<User> findById(Long id);
 
-	default User findByIdOrElseThrow(String email) {
-		return findByEmail(email).orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "회원 조회 실패"));
-	}
+    Optional<User> findByEmail(String email);
+
+    Optional<User> findByPlatformId(Long platformId);
+
+    User save(User saveUser);
+
+    default User findByEmailOrElseThrow(String email) {
+        return findByEmail(email).orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "회원 조회 실패"));
+    }
+
+    default User findByIdOrElseThrow(Long id) {
+        return findById(id).orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "회원 조회 실패"));
+    }
+
 }

--- a/src/main/java/com/example/temp/user/domain/UserRepository.java
+++ b/src/main/java/com/example/temp/user/domain/UserRepository.java
@@ -1,6 +1,7 @@
 package com.example.temp.user.domain;
 
 import com.example.temp.common.exception.CustomException;
+import com.example.temp.user.domain.value.PlatformType;
 import org.springframework.data.repository.Repository;
 import org.springframework.http.HttpStatus;
 
@@ -12,13 +13,9 @@ public interface UserRepository extends Repository<User, Long> {
 
     Optional<User> findByEmail(String email);
 
-    Optional<User> findByPlatformId(Long platformId);
+    Optional<User> findByPlatformTypeAndPlatformId(PlatformType platformType, Long platformId);
 
     User save(User saveUser);
-
-    default User findByEmailOrElseThrow(String email) {
-        return findByEmail(email).orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "회원 조회 실패"));
-    }
 
     default User findByIdOrElseThrow(Long id) {
         return findById(id).orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "회원 조회 실패"));

--- a/src/main/java/com/example/temp/user/domain/UserRepository.java
+++ b/src/main/java/com/example/temp/user/domain/UserRepository.java
@@ -10,6 +10,8 @@ import com.example.temp.common.exception.CustomException;
 public interface UserRepository extends Repository<User, Long> {
 
 	Optional<User> findById(Long id);
+	Optional<User> findByEmail(String email);
+	User save(User saveUser);
 
 	default User findByIdOrElseThrow(Long id) {
 		return findById(id).orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "회원 조회 실패"));

--- a/src/main/java/com/example/temp/user/domain/UserRole.java
+++ b/src/main/java/com/example/temp/user/domain/UserRole.java
@@ -1,0 +1,14 @@
+package com.example.temp.user.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserRole {
+    UNAUTH("미인증"),
+    USER("유저"),
+    WITHDRAW("탈퇴");
+
+    private final String text;
+}

--- a/src/main/java/com/example/temp/user/domain/value/PlatformType.java
+++ b/src/main/java/com/example/temp/user/domain/value/PlatformType.java
@@ -1,0 +1,32 @@
+package com.example.temp.user.domain.value;
+
+import lombok.RequiredArgsConstructor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public enum PlatformType {
+    KAKAO("kakao");
+
+    private static final Map<String, PlatformType> NAME_TO_ENUM_MAP = new HashMap<>();
+    private final String name;
+
+    static {
+        for (PlatformType platformType : PlatformType.values()) {
+            NAME_TO_ENUM_MAP.put(platformType.getName().toLowerCase(), platformType);
+        }
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public static PlatformType fromName(String name) {
+        PlatformType platformType = NAME_TO_ENUM_MAP.get(name.toLowerCase());
+        if (platformType == null) {
+            throw new IllegalArgumentException("No enum constant with name " + name);
+        }
+        return platformType;
+    }
+}

--- a/src/main/java/com/example/temp/user/domain/value/PlatformType.java
+++ b/src/main/java/com/example/temp/user/domain/value/PlatformType.java
@@ -9,24 +9,5 @@ import java.util.Map;
 public enum PlatformType {
     KAKAO("kakao");
 
-    private static final Map<String, PlatformType> NAME_TO_ENUM_MAP = new HashMap<>();
     private final String name;
-
-    static {
-        for (PlatformType platformType : PlatformType.values()) {
-            NAME_TO_ENUM_MAP.put(platformType.getName().toLowerCase(), platformType);
-        }
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public static PlatformType fromName(String name) {
-        PlatformType platformType = NAME_TO_ENUM_MAP.get(name.toLowerCase());
-        if (platformType == null) {
-            throw new IllegalArgumentException("No enum constant with name " + name);
-        }
-        return platformType;
-    }
 }

--- a/src/main/java/com/example/temp/user/domain/value/PlatformType.java
+++ b/src/main/java/com/example/temp/user/domain/value/PlatformType.java
@@ -2,12 +2,8 @@ package com.example.temp.user.domain.value;
 
 import lombok.RequiredArgsConstructor;
 
-import java.util.HashMap;
-import java.util.Map;
-
 @RequiredArgsConstructor
 public enum PlatformType {
-    KAKAO("kakao");
-
-    private final String name;
+    NONE,
+    KAKAO;
 }

--- a/src/main/java/com/example/temp/user/domain/value/UserRole.java
+++ b/src/main/java/com/example/temp/user/domain/value/UserRole.java
@@ -1,4 +1,4 @@
-package com.example.temp.user.domain;
+package com.example.temp.user.domain.value;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/temp/user/dto/AuthLoginResponse.java
+++ b/src/main/java/com/example/temp/user/dto/AuthLoginResponse.java
@@ -1,0 +1,19 @@
+package com.example.temp.user.dto;
+
+import com.example.temp.user.domain.UserRole;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class AuthLoginResponse {
+    private String accessToken;
+    private String refreshToken;
+    private UserRole role;
+
+    @Builder
+    public AuthLoginResponse(String accessToken, String refreshToken, UserRole role) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.role = role;
+    }
+}

--- a/src/main/java/com/example/temp/user/dto/AuthLoginResponse.java
+++ b/src/main/java/com/example/temp/user/dto/AuthLoginResponse.java
@@ -1,6 +1,6 @@
 package com.example.temp.user.dto;
 
-import com.example.temp.user.domain.UserRole;
+import com.example.temp.user.domain.value.UserRole;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/src/main/java/com/example/temp/user/dto/JwtToken.java
+++ b/src/main/java/com/example/temp/user/dto/JwtToken.java
@@ -1,0 +1,16 @@
+package com.example.temp.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class JwtToken {
+    private String accessToken;
+    private String refreshToken;
+
+    @Builder
+    public JwtToken(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/example/temp/user/dto/UpdatedUserProfileRequest.java
+++ b/src/main/java/com/example/temp/user/dto/UpdatedUserProfileRequest.java
@@ -1,0 +1,13 @@
+package com.example.temp.user.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class UpdatedUserProfileRequest {
+    private String nickname;
+    private Long favoriteTeam;
+    private String profileImageUrl;
+    private String oneLiner; // 한 줄 소개
+}

--- a/src/main/java/com/example/temp/user/dto/UserProfileView.java
+++ b/src/main/java/com/example/temp/user/dto/UserProfileView.java
@@ -1,7 +1,7 @@
 package com.example.temp.user.dto;
 
 import com.example.temp.user.domain.User;
-import com.example.temp.user.domain.UserRole;
+import com.example.temp.user.domain.value.UserRole;
 
 public record UserProfileView(String email, String nickname, String profileImageUrl, String name, UserRole userRole) {
 

--- a/src/main/java/com/example/temp/user/dto/UserProfileView.java
+++ b/src/main/java/com/example/temp/user/dto/UserProfileView.java
@@ -3,9 +3,10 @@ package com.example.temp.user.dto;
 import com.example.temp.user.domain.User;
 import com.example.temp.user.domain.value.UserRole;
 
-public record UserProfileView(String email, String nickname, String profileImageUrl, String name, UserRole userRole) {
+public record UserProfileView(String email, String nickname, String profileImageUrl, String name, String oneLiner,
+                              UserRole userRole, long favoriteTeam) {
 
     public UserProfileView(User user) {
-        this(user.getEmail(), user.getNickname(), user.getProfileImageUrl(), user.getName(), user.getUserRole());
+        this(user.getEmail(), user.getNickname(), user.getProfileImageUrl(), user.getName(), user.getOneLiner(), user.getUserRole(), user.getFavoriteTeam());
     }
 }

--- a/src/main/java/com/example/temp/user/dto/UserProfileView.java
+++ b/src/main/java/com/example/temp/user/dto/UserProfileView.java
@@ -1,11 +1,11 @@
 package com.example.temp.user.dto;
 
-import com.example.temp.common.util.IdUtil;
 import com.example.temp.user.domain.User;
+import com.example.temp.user.domain.UserRole;
 
-public record UserProfileView(String id, String nickname) {
+public record UserProfileView(String email, String nickname, String profileImageUrl, String name, UserRole userRole) {
 
-	public UserProfileView(User user) {
-		this(IdUtil.toString(user.getId()), user.getNickname());
-	}
+    public UserProfileView(User user) {
+        this(user.getEmail(), user.getNickname(), user.getProfileImageUrl(), user.getName(), user.getUserRole());
+    }
 }

--- a/src/main/java/com/example/temp/user/service/CreateUserService.java
+++ b/src/main/java/com/example/temp/user/service/CreateUserService.java
@@ -1,0 +1,8 @@
+package com.example.temp.user.service;
+
+import com.example.temp.user.dto.AuthLoginResponse;
+import com.example.temp.user.service.oauth.response.OAuthResponse;
+
+public interface CreateUserService {
+    AuthLoginResponse doService(OAuthResponse response);
+}

--- a/src/main/java/com/example/temp/user/service/FindUserProfileService.java
+++ b/src/main/java/com/example/temp/user/service/FindUserProfileService.java
@@ -4,5 +4,5 @@ import com.example.temp.user.dto.UserProfileView;
 
 public interface FindUserProfileService {
 
-	UserProfileView doService(Long userId);
+	UserProfileView doService(String email);
 }

--- a/src/main/java/com/example/temp/user/service/FindUserProfileService.java
+++ b/src/main/java/com/example/temp/user/service/FindUserProfileService.java
@@ -4,5 +4,5 @@ import com.example.temp.user.dto.UserProfileView;
 
 public interface FindUserProfileService {
 
-	UserProfileView doService(String email);
+    UserProfileView doService(long id);
 }

--- a/src/main/java/com/example/temp/user/service/UpdateUserProfileService.java
+++ b/src/main/java/com/example/temp/user/service/UpdateUserProfileService.java
@@ -1,0 +1,8 @@
+package com.example.temp.user.service;
+
+import com.example.temp.user.dto.UpdatedUserProfileRequest;
+import com.example.temp.user.dto.UserProfileView;
+
+public interface UpdateUserProfileService {
+    public UserProfileView doService(long userId, UpdatedUserProfileRequest updatedUserProfileRequest);
+}

--- a/src/main/java/com/example/temp/user/service/impl/CreateUserServiceImpl.java
+++ b/src/main/java/com/example/temp/user/service/impl/CreateUserServiceImpl.java
@@ -36,7 +36,7 @@ public class CreateUserServiceImpl implements CreateUserService {
                 });
 
         // 기존 회원의 경우 name, profileImageUrl 변하면 update
-        findUser.updateProfile(oAuthResponse.getName(), oAuthResponse.getProfileImageUrl());
+        findUser.updateProfile(oAuthResponse.getNickname(), oAuthResponse.getProfileImageUrl());
 
         // JWT Access Token, Refresh Token 발급
         JwtToken tokens = createJwtToken(findUser);

--- a/src/main/java/com/example/temp/user/service/impl/CreateUserServiceImpl.java
+++ b/src/main/java/com/example/temp/user/service/impl/CreateUserServiceImpl.java
@@ -11,8 +11,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.HashMap;
-
 @Service
 @Slf4j
 @RequiredArgsConstructor
@@ -21,15 +19,11 @@ public class CreateUserServiceImpl implements CreateUserService {
     private final UserRepository userRepository;
     private final JwtTokenService jwtService;
 
-    private static final String ROLE_CLAIM = "role";
-    private static final String NAME_CLAIM = "name";
-    private static final String PROFILE_IMAGE_CLAIM = "profileImageUrl";
-
     @Override
     @Transactional
     public AuthLoginResponse doService(OAuthResponse oAuthResponse) {
         // OAuth 로그인을 시도한 사용자 정보가 DB에 존재하는지 확인 후 없다면 등록
-        User findUser = userRepository.findByEmail(oAuthResponse.getEmail())
+        User findUser = userRepository.findByPlatformId(oAuthResponse.getPlatformId())
                 .orElseGet(() -> {
                     User saveUser = User.build(oAuthResponse);
                     return userRepository.save(saveUser);
@@ -39,7 +33,7 @@ public class CreateUserServiceImpl implements CreateUserService {
         findUser.updateProfile(oAuthResponse.getNickname(), oAuthResponse.getProfileImageUrl());
 
         // JWT Access Token, Refresh Token 발급
-        JwtToken tokens = createJwtToken(findUser);
+        JwtToken tokens = jwtService.createJwtToken(findUser);
         log.info("access token:{}", tokens.getAccessToken());
         log.info("refresh token:{}", tokens.getRefreshToken());
 
@@ -50,30 +44,4 @@ public class CreateUserServiceImpl implements CreateUserService {
                 .build();
     }
 
-    private JwtToken createJwtToken(User user) {
-        // JWT 토큰 생성을 위한 claims 생성
-        HashMap<String, String> claims = new HashMap<>();
-        claims.put(ROLE_CLAIM, user.getUserRole().name());
-        claims.put(NAME_CLAIM, user.getName());
-        claims.put(PROFILE_IMAGE_CLAIM, user.getProfileImageUrl());
-
-        // Access Token 생성
-        final String accessToken = jwtService.generateAccessToken(claims, user);
-        // Refresh Token 생성
-        final String refreshToken = jwtService.generateRefreshToken(claims, user);
-
-        log.info(">>>> {} generate Tokens", user.getName());
-
-        // Refresh Token 저장 - REDIS
-//        RefreshToken rt = RefreshToken.builder()
-//                .refreshToken(refreshToken)
-//                .email(user.getEmail())
-//                .build();
-//        refreshTokenService.saveRefreshToken(rt);
-
-        return JwtToken.builder()
-                .accessToken(accessToken)
-                .refreshToken(refreshToken)
-                .build();
-    }
 }

--- a/src/main/java/com/example/temp/user/service/impl/CreateUserServiceImpl.java
+++ b/src/main/java/com/example/temp/user/service/impl/CreateUserServiceImpl.java
@@ -23,7 +23,7 @@ public class CreateUserServiceImpl implements CreateUserService {
     @Transactional
     public AuthLoginResponse doService(OAuthResponse oAuthResponse) {
         // OAuth 로그인을 시도한 사용자 정보가 DB에 존재하는지 확인 후 없다면 등록
-        User findUser = userRepository.findByPlatformId(oAuthResponse.getPlatformId())
+        User findUser = userRepository.findByPlatformTypeAndPlatformId(oAuthResponse.getPlatformType(), oAuthResponse.getPlatformId())
                 .orElseGet(() -> {
                     User saveUser = User.build(oAuthResponse);
                     return userRepository.save(saveUser);

--- a/src/main/java/com/example/temp/user/service/impl/CreateUserServiceImpl.java
+++ b/src/main/java/com/example/temp/user/service/impl/CreateUserServiceImpl.java
@@ -1,0 +1,79 @@
+package com.example.temp.user.service.impl;
+
+import com.example.temp.user.domain.User;
+import com.example.temp.user.domain.UserRepository;
+import com.example.temp.user.dto.AuthLoginResponse;
+import com.example.temp.user.dto.JwtToken;
+import com.example.temp.user.service.CreateUserService;
+import com.example.temp.user.service.oauth.response.OAuthResponse;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class CreateUserServiceImpl implements CreateUserService {
+
+    private final UserRepository userRepository;
+    private final JwtTokenService jwtService;
+
+    private static final String ROLE_CLAIM = "role";
+    private static final String NAME_CLAIM = "name";
+    private static final String PROFILE_IMAGE_CLAIM = "profileImageUrl";
+
+    @Override
+    @Transactional
+    public AuthLoginResponse doService(OAuthResponse oAuthResponse) {
+        // OAuth 로그인을 시도한 사용자 정보가 DB에 존재하는지 확인 후 없다면 등록
+        User findUser = userRepository.findByEmail(oAuthResponse.getEmail())
+                .orElseGet(() -> {
+                    User saveUser = User.build(oAuthResponse);
+                    return userRepository.save(saveUser);
+                });
+
+        // 기존 회원의 경우 name, profileImageUrl 변하면 update
+        findUser.updateProfile(oAuthResponse.getName(), oAuthResponse.getProfileImageUrl());
+
+        // JWT Access Token, Refresh Token 발급
+        JwtToken tokens = createJwtToken(findUser);
+        log.info("access token:{}", tokens.getAccessToken());
+        log.info("refresh token:{}", tokens.getRefreshToken());
+
+        return AuthLoginResponse.builder()
+                .accessToken(tokens.getAccessToken())
+                .refreshToken(tokens.getRefreshToken())
+                .role(findUser.getUserRole())
+                .build();
+    }
+
+    private JwtToken createJwtToken(User user) {
+        // JWT 토큰 생성을 위한 claims 생성
+        HashMap<String, String> claims = new HashMap<>();
+        claims.put(ROLE_CLAIM, user.getUserRole().name());
+        claims.put(NAME_CLAIM, user.getName());
+        claims.put(PROFILE_IMAGE_CLAIM, user.getProfileImageUrl());
+
+        // Access Token 생성
+        final String accessToken = jwtService.generateAccessToken(claims, user);
+        // Refresh Token 생성
+        final String refreshToken = jwtService.generateRefreshToken(claims, user);
+
+        log.info(">>>> {} generate Tokens", user.getName());
+
+        // Refresh Token 저장 - REDIS
+//        RefreshToken rt = RefreshToken.builder()
+//                .refreshToken(refreshToken)
+//                .email(user.getEmail())
+//                .build();
+//        refreshTokenService.saveRefreshToken(rt);
+
+        return JwtToken.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/com/example/temp/user/service/impl/CreateUserServiceImpl.java
+++ b/src/main/java/com/example/temp/user/service/impl/CreateUserServiceImpl.java
@@ -29,9 +29,6 @@ public class CreateUserServiceImpl implements CreateUserService {
                     return userRepository.save(saveUser);
                 });
 
-        // 기존 회원의 경우 name, profileImageUrl 변하면 update
-        findUser.updateProfile(oAuthResponse.getNickname(), oAuthResponse.getProfileImageUrl());
-
         // JWT Access Token, Refresh Token 발급
         JwtToken tokens = jwtService.createJwtToken(findUser);
         log.info("access token:{}", tokens.getAccessToken());

--- a/src/main/java/com/example/temp/user/service/impl/FindUserProfileServiceImpl.java
+++ b/src/main/java/com/example/temp/user/service/impl/FindUserProfileServiceImpl.java
@@ -1,25 +1,23 @@
 package com.example.temp.user.service.impl;
 
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.example.temp.user.domain.User;
 import com.example.temp.user.domain.UserRepository;
 import com.example.temp.user.dto.UserProfileView;
 import com.example.temp.user.service.FindUserProfileService;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class FindUserProfileServiceImpl implements FindUserProfileService {
 
-	private final UserRepository userRepository;
+    private final UserRepository userRepository;
 
-	@Override
-	@Transactional(readOnly = true)
-	public UserProfileView doService(String email) {
-		User user = userRepository.findByIdOrElseThrow(email);
-		return new UserProfileView(user);
-	}
+    @Override
+    @Transactional(readOnly = true)
+    public UserProfileView doService(long id) {
+        User user = userRepository.findByIdOrElseThrow(id);
+        return new UserProfileView(user);
+    }
 }

--- a/src/main/java/com/example/temp/user/service/impl/FindUserProfileServiceImpl.java
+++ b/src/main/java/com/example/temp/user/service/impl/FindUserProfileServiceImpl.java
@@ -18,8 +18,8 @@ public class FindUserProfileServiceImpl implements FindUserProfileService {
 
 	@Override
 	@Transactional(readOnly = true)
-	public UserProfileView doService(Long userId) {
-		User user = userRepository.findByIdOrElseThrow(userId);
+	public UserProfileView doService(String email) {
+		User user = userRepository.findByIdOrElseThrow(email);
 		return new UserProfileView(user);
 	}
 }

--- a/src/main/java/com/example/temp/user/service/impl/JwtTokenService.java
+++ b/src/main/java/com/example/temp/user/service/impl/JwtTokenService.java
@@ -1,0 +1,146 @@
+package com.example.temp.user.service.impl;
+
+import com.example.temp.user.domain.UserRole;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+@Service
+public class JwtTokenService {
+
+    @Value("${jwt.secretKey}")
+    private String secretKey;
+    @Value("${jwt.expiration-time}")
+    private long expirationTime;
+
+    /*
+     *   Token에서 사용자 이름 추출
+     */
+    public String extractUsername(String token) {
+        return extractClaim(token, Claims::getSubject);
+    }
+
+    private <T> T extractClaim(String token, Function<Claims, T> claimsResolver) {
+        Claims claims = extractAllClaims(token);
+
+        return claimsResolver.apply(claims);
+    }
+
+    /*
+     *   AccessToken 생성
+     */
+    public String generateAccessToken(UserDetails userDetails) {
+        return generateAccessToken(new HashMap<>(), userDetails, new Date(System.currentTimeMillis() + expirationTime));
+    }
+
+    public String generateAccessToken(Map<String, String> extraClaims, UserDetails userDetails) {
+        return generateAccessToken(extraClaims, userDetails, new Date(System.currentTimeMillis() + expirationTime));
+    }
+
+    public String generateAccessToken(Map<String, String> extraClaims, UserDetails userDetails, Date expiredTime) {
+        return Jwts.builder()
+                .setClaims(extraClaims)
+                .setSubject(userDetails.getUsername())
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(expiredTime)
+                .signWith(getSignInkey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    /*
+     *   RefreshToken 생성
+     */
+    public String generateRefreshToken(UserDetails userDetails) {
+        return generateAccessToken(new HashMap<>(), userDetails, new Date(System.currentTimeMillis() + expirationTime * 7));
+    }
+
+    public String generateRefreshToken(Map<String, String> extraClaims, UserDetails userDetails) {
+        return generateRefreshToken(extraClaims, userDetails, new Date(System.currentTimeMillis() + expirationTime * 7));
+    }
+
+    public String generateRefreshToken(Map<String, String> extraClaims, UserDetails userDetails, Date expiredTime) {
+        return Jwts.builder()
+                .setClaims(extraClaims)
+                .setSubject(userDetails.getUsername())
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(expiredTime)
+                .signWith(getSignInkey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+
+    /*
+     *   Token 검증
+     */
+    public boolean isTokenValid(String token, String username) {
+        Claims claims = extractAllClaims(token);
+
+        try {
+            if (!claims.containsKey("role")) {
+                UserRole.valueOf(claims.get("role", String.class));
+                return false;
+            }
+            if (!claims.containsKey("name")) return false;
+            if (!claims.containsKey("profileImageUrl")) return false;
+        } catch (RuntimeException e) { // covered for NullPointException, IllegalArgumentException
+            throw new JwtException("잘못된 정보입니다");
+        }
+
+        String claimsSubject = claims.getSubject();
+
+        return (claimsSubject.equals(username)) && !isTokenExpired(token);
+    }
+
+    public boolean isTokenExpired(String token) {
+        return extractExpiration(token).before(new Date());
+    }
+
+
+    /*
+     *   Token 정보 추출
+     */
+    public Date extractExpiration(String token) {
+        return extractClaim(token, Claims::getExpiration);
+    }
+
+    public Claims extractAllClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSignInkey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    private Key getSignInkey() {
+        byte[] keyBytes = Base64.getDecoder().decode(secretKey);
+
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String generateExpiredAccessToken(Map<String, String> claims, UserDetails user) {
+        Date now = new Date();
+
+        // 만료기간을 현재 시각보다 이전으로
+        Date expiryTime = new Date(now.getTime() - 1000);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setSubject(user.getUsername())
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(expiryTime)
+                .signWith(getSignInkey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+}

--- a/src/main/java/com/example/temp/user/service/impl/JwtTokenService.java
+++ b/src/main/java/com/example/temp/user/service/impl/JwtTokenService.java
@@ -32,7 +32,7 @@ public class JwtTokenService {
     private static final String NAME_CLAIM = "name";
     private static final String PROFILE_IMAGE_CLAIM = "profileImageUrl";
 
-    @Value("${jwt.secretKey}")
+    @Value("${jwt.secret-key}")
     private String secretKey;
     @Value("${jwt.expiration-time}")
     private long expirationTime;

--- a/src/main/java/com/example/temp/user/service/impl/JwtTokenService.java
+++ b/src/main/java/com/example/temp/user/service/impl/JwtTokenService.java
@@ -1,6 +1,6 @@
 package com.example.temp.user.service.impl;
 
-import com.example.temp.user.domain.UserRole;
+import com.example.temp.user.domain.value.UserRole;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;

--- a/src/main/java/com/example/temp/user/service/impl/OAuthService.java
+++ b/src/main/java/com/example/temp/user/service/impl/OAuthService.java
@@ -1,5 +1,6 @@
 package com.example.temp.user.service.impl;
 
+import com.example.temp.user.domain.value.PlatformType;
 import com.example.temp.user.service.oauth.OAuthAdapter;
 import com.example.temp.user.service.oauth.OAuthFactory;
 import com.example.temp.user.service.oauth.OAuthUrlBuilder;
@@ -16,12 +17,12 @@ import java.util.Map;
 @Slf4j
 public class OAuthService {
 
-    private final Map<String, OAuthFactory> adapterMap;
+    private final Map<PlatformType, OAuthFactory> adapterMap;
 
     public OAuthService(OAuthKakaoAdapter oAuthKakaoAdapter, KakaoUrlBuilder kakaoURLBuilder) {
         // 객체 생성 시점에 맵 구축
         this.adapterMap = new HashMap<>() {{
-            put("kakao", OAuthFactory.builder()
+            put(PlatformType.KAKAO, OAuthFactory.builder()
                     .oAuthAdapter(oAuthKakaoAdapter)
                     .oAuthURLBuilder(kakaoURLBuilder)
                     .build());
@@ -29,13 +30,13 @@ public class OAuthService {
     }
 
     public String loginPage(String platformType) {
-        return adapterMap.get(platformType)
+        return adapterMap.get(PlatformType.fromName(platformType))
                 .getOAuthURLBuilder()
                 .authorize();
     }
 
     public OAuthResponse login(String platformType, String code) {
-        OAuthFactory factory = getOAuthFactory(platformType);
+        OAuthFactory factory = getOAuthFactory(PlatformType.fromName(platformType));
         OAuthUrlBuilder urlBuilder = factory.getOAuthURLBuilder();
         OAuthAdapter adapter = factory.getOAuthAdapter();
         log.info(">>>> {} Login Start", platformType);
@@ -47,7 +48,7 @@ public class OAuthService {
         return profile;
     }
 
-    private OAuthFactory getOAuthFactory(String platformType) {
+    private OAuthFactory getOAuthFactory(PlatformType platformType) {
         return adapterMap.get(platformType);
     }
 }

--- a/src/main/java/com/example/temp/user/service/impl/OAuthService.java
+++ b/src/main/java/com/example/temp/user/service/impl/OAuthService.java
@@ -37,7 +37,6 @@ public class OAuthService {
 
     public OAuthResponse login(String platformType, String code) {
         OAuthFactory factory = getOAuthFactory(PlatformType.fromName(platformType));
-        OAuthUrlBuilder urlBuilder = factory.getOAuthURLBuilder();
         OAuthAdapter adapter = factory.getOAuthAdapter();
         log.info(">>>> {} Login Start", platformType);
 

--- a/src/main/java/com/example/temp/user/service/impl/OAuthService.java
+++ b/src/main/java/com/example/temp/user/service/impl/OAuthService.java
@@ -1,0 +1,53 @@
+package com.example.temp.user.service.impl;
+
+import com.example.temp.user.service.oauth.OAuthAdapter;
+import com.example.temp.user.service.oauth.OAuthFactory;
+import com.example.temp.user.service.oauth.OAuthUrlBuilder;
+import com.example.temp.user.service.oauth.kakao.KakaoUrlBuilder;
+import com.example.temp.user.service.oauth.kakao.OAuthKakaoAdapter;
+import com.example.temp.user.service.oauth.response.OAuthResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@Slf4j
+public class OAuthService {
+
+    private final Map<String, OAuthFactory> adapterMap;
+
+    public OAuthService(OAuthKakaoAdapter oAuthKakaoAdapter, KakaoUrlBuilder kakaoURLBuilder) {
+        // 객체 생성 시점에 맵 구축
+        this.adapterMap = new HashMap<>() {{
+            put("kakao", OAuthFactory.builder()
+                    .oAuthAdapter(oAuthKakaoAdapter)
+                    .oAuthURLBuilder(kakaoURLBuilder)
+                    .build());
+        }};
+    }
+
+    public String loginPage(String platformType) {
+        return adapterMap.get(platformType)
+                .getOAuthURLBuilder()
+                .authorize();
+    }
+
+    public OAuthResponse login(String platformType, String code) {
+        OAuthFactory factory = getOAuthFactory(platformType);
+        OAuthUrlBuilder urlBuilder = factory.getOAuthURLBuilder();
+        OAuthAdapter adapter = factory.getOAuthAdapter();
+        log.info(">>>> {} Login Start", platformType);
+
+        String accessToken = adapter.getToken(code);
+        OAuthResponse profile = adapter.getProfile(accessToken);
+        log.info(">>>> {} Login Success", platformType);
+
+        return profile;
+    }
+
+    private OAuthFactory getOAuthFactory(String platformType) {
+        return adapterMap.get(platformType);
+    }
+}

--- a/src/main/java/com/example/temp/user/service/impl/OAuthService.java
+++ b/src/main/java/com/example/temp/user/service/impl/OAuthService.java
@@ -30,13 +30,13 @@ public class OAuthService {
     }
 
     public String loginPage(String platformType) {
-        return adapterMap.get(PlatformType.fromName(platformType))
+        return adapterMap.get(PlatformType.valueOf(platformType.toUpperCase()))
                 .getOAuthURLBuilder()
                 .authorize();
     }
 
     public OAuthResponse login(String platformType, String code) {
-        OAuthFactory factory = getOAuthFactory(PlatformType.fromName(platformType));
+        OAuthFactory factory = getOAuthFactory(PlatformType.valueOf(platformType.toUpperCase()));
         OAuthAdapter adapter = factory.getOAuthAdapter();
         log.info(">>>> {} Login Start", platformType);
 

--- a/src/main/java/com/example/temp/user/service/impl/UpdateUserProfileServiceImpl.java
+++ b/src/main/java/com/example/temp/user/service/impl/UpdateUserProfileServiceImpl.java
@@ -1,0 +1,24 @@
+package com.example.temp.user.service.impl;
+
+import com.example.temp.user.domain.User;
+import com.example.temp.user.domain.UserRepository;
+import com.example.temp.user.dto.UpdatedUserProfileRequest;
+import com.example.temp.user.dto.UserProfileView;
+import com.example.temp.user.service.UpdateUserProfileService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UpdateUserProfileServiceImpl implements UpdateUserProfileService {
+    private final UserRepository userRepository;
+
+    @Override
+    public UserProfileView doService(long userId, UpdatedUserProfileRequest updatedUserProfileRequest) {
+        User user = userRepository.findByIdOrElseThrow(userId);
+        user.updateProfile(updatedUserProfileRequest);
+        return new UserProfileView(user);
+    }
+}

--- a/src/main/java/com/example/temp/user/service/impl/UserDetailsServiceImpl.java
+++ b/src/main/java/com/example/temp/user/service/impl/UserDetailsServiceImpl.java
@@ -1,5 +1,7 @@
 package com.example.temp.user.service.impl;
 
+import com.example.temp.common.entity.CustomUserDetails;
+import com.example.temp.user.domain.User;
 import com.example.temp.user.domain.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -15,7 +17,9 @@ public class UserDetailsServiceImpl implements UserDetailsService {
     private final UserRepository userRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        return userRepository.findByIdOrElseThrow(email);
+    public UserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
+        long idParsedLong = Long.parseLong(id);
+        User user = userRepository.findByIdOrElseThrow(idParsedLong);
+        return CustomUserDetails.create(user);
     }
 }

--- a/src/main/java/com/example/temp/user/service/impl/UserDetailsServiceImpl.java
+++ b/src/main/java/com/example/temp/user/service/impl/UserDetailsServiceImpl.java
@@ -1,0 +1,21 @@
+package com.example.temp.user.service.impl;
+
+import com.example.temp.user.domain.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        return userRepository.findByIdOrElseThrow(email);
+    }
+}

--- a/src/main/java/com/example/temp/user/service/oauth/OAuthAdapter.java
+++ b/src/main/java/com/example/temp/user/service/oauth/OAuthAdapter.java
@@ -1,0 +1,11 @@
+package com.example.temp.user.service.oauth;
+
+import com.example.temp.user.service.oauth.response.OAuthResponse;
+
+public interface OAuthAdapter {
+
+    String getToken(String tokenURL);
+
+    OAuthResponse getProfile(String accessToken);
+
+}

--- a/src/main/java/com/example/temp/user/service/oauth/OAuthFactory.java
+++ b/src/main/java/com/example/temp/user/service/oauth/OAuthFactory.java
@@ -1,0 +1,18 @@
+package com.example.temp.user.service.oauth;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class OAuthFactory {
+
+    private OAuthUrlBuilder oAuthURLBuilder;
+    private OAuthAdapter oAuthAdapter;
+
+    @Builder
+    private OAuthFactory(OAuthUrlBuilder oAuthURLBuilder, OAuthAdapter oAuthAdapter) {
+        this.oAuthURLBuilder = oAuthURLBuilder;
+        this.oAuthAdapter = oAuthAdapter;
+    }
+}
+

--- a/src/main/java/com/example/temp/user/service/oauth/OAuthUrlBuilder.java
+++ b/src/main/java/com/example/temp/user/service/oauth/OAuthUrlBuilder.java
@@ -1,0 +1,5 @@
+package com.example.temp.user.service.oauth;
+
+public interface OAuthUrlBuilder {
+    String authorize();
+}

--- a/src/main/java/com/example/temp/user/service/oauth/kakao/KakaoProfileClient.java
+++ b/src/main/java/com/example/temp/user/service/oauth/kakao/KakaoProfileClient.java
@@ -1,0 +1,39 @@
+package com.example.temp.user.service.oauth.kakao;
+
+
+import com.example.temp.common.exception.CustomException;
+import com.example.temp.user.service.oauth.response.KakaoProfileResponse;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoProfileClient {
+
+    private final KakaoUrlBuilder kakaoUrlBuilder;
+
+    public KakaoProfileResponse getProfile(String accessToken) {
+
+        KakaoProfileResponse profile = WebClient.create(kakaoUrlBuilder.profile())
+                .post()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, clientResponse ->
+                        Mono.error(new CustomException(HttpStatus.BAD_REQUEST, "잘못된 접근입니다.")))
+                .onStatus(HttpStatusCode::is5xxServerError, clientResponse ->
+                        Mono.error(new CustomException(HttpStatus.BAD_GATEWAY, "Internal Server Error")))
+                .bodyToMono(KakaoProfileResponse.class)
+                .block();
+
+        return profile;
+    }
+}
+

--- a/src/main/java/com/example/temp/user/service/oauth/kakao/KakaoProfileClient.java
+++ b/src/main/java/com/example/temp/user/service/oauth/kakao/KakaoProfileClient.java
@@ -21,7 +21,7 @@ public class KakaoProfileClient {
 
     public KakaoProfileResponse getProfile(String accessToken) {
 
-        KakaoProfileResponse profile = WebClient.create(kakaoUrlBuilder.profile())
+        return WebClient.create(kakaoUrlBuilder.getProfileUri())
                 .post()
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
                 .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
@@ -32,8 +32,6 @@ public class KakaoProfileClient {
                         Mono.error(new CustomException(HttpStatus.BAD_GATEWAY, "Internal Server Error")))
                 .bodyToMono(KakaoProfileResponse.class)
                 .block();
-
-        return profile;
     }
 }
 

--- a/src/main/java/com/example/temp/user/service/oauth/kakao/KakaoProfileClient.java
+++ b/src/main/java/com/example/temp/user/service/oauth/kakao/KakaoProfileClient.java
@@ -5,7 +5,6 @@ import com.example.temp.common.exception.CustomException;
 import com.example.temp.user.service.oauth.response.KakaoProfileResponse;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
@@ -17,13 +16,14 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 public class KakaoProfileClient {
 
+    public static final String BEARER = "Bearer ";
     private final KakaoUrlBuilder kakaoUrlBuilder;
 
     public KakaoProfileResponse getProfile(String accessToken) {
 
         return WebClient.create(kakaoUrlBuilder.getProfileUri())
                 .post()
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .header(HttpHeaders.AUTHORIZATION, BEARER + accessToken)
                 .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
                 .retrieve()
                 .onStatus(HttpStatusCode::is4xxClientError, clientResponse ->

--- a/src/main/java/com/example/temp/user/service/oauth/kakao/KakaoTokenClient.java
+++ b/src/main/java/com/example/temp/user/service/oauth/kakao/KakaoTokenClient.java
@@ -1,0 +1,41 @@
+package com.example.temp.user.service.oauth.kakao;
+
+import com.example.temp.common.exception.CustomException;
+import com.example.temp.user.service.oauth.response.KakaoTokenResponse;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoTokenClient {
+
+    private final KakaoUrlBuilder kakaoUrlBuilder;
+
+    public String getAccessToken(String code) {
+        KakaoTokenResponse kakaoTokenResponse = WebClient.create(kakaoUrlBuilder.getTokenUri())
+                .post()
+                .uri(uriBuilder -> uriBuilder
+                        .queryParam("grant_type", "authorization_code")
+                        .queryParam("client_id", kakaoUrlBuilder.getClientId())
+                        .queryParam("redirect_uri", kakaoUrlBuilder.getRedirectUri())
+                        .queryParam("code", code)
+                        .build(true))
+                .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, clientResponse ->
+                        Mono.error(new CustomException(HttpStatus.BAD_GATEWAY, "Invalid Parameter")))
+                .onStatus(HttpStatusCode::is5xxServerError, clientResponse ->
+                        Mono.error(new CustomException(HttpStatus.BAD_GATEWAY, "Internal Server Error")))
+                .bodyToMono(KakaoTokenResponse.class)
+                .block();
+
+        return kakaoTokenResponse.getAccessToken();
+    }
+
+}

--- a/src/main/java/com/example/temp/user/service/oauth/kakao/KakaoTokenClient.java
+++ b/src/main/java/com/example/temp/user/service/oauth/kakao/KakaoTokenClient.java
@@ -15,21 +15,27 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 public class KakaoTokenClient {
 
+    public static final String GRANT_TYPE = "grant_type";
+    public static final String AUTHORIZATION_CODE = "authorization_code";
+    public static final String CLIENT_ID = "client_id";
+    public static final String REDIRECT_URI = "redirect_uri";
+    public static final String CODE = "code";
+
     private final KakaoUrlBuilder kakaoUrlBuilder;
 
     public String getAccessToken(String code) {
         KakaoTokenResponse kakaoTokenResponse = WebClient.create(kakaoUrlBuilder.getTokenUri())
                 .post()
                 .uri(uriBuilder -> uriBuilder
-                        .queryParam("grant_type", "authorization_code")
-                        .queryParam("client_id", kakaoUrlBuilder.getClientId())
-                        .queryParam("redirect_uri", kakaoUrlBuilder.getRedirectUri())
-                        .queryParam("code", code)
+                        .queryParam(GRANT_TYPE, AUTHORIZATION_CODE)
+                        .queryParam(CLIENT_ID, kakaoUrlBuilder.getClientId())
+                        .queryParam(REDIRECT_URI, kakaoUrlBuilder.getRedirectUri())
+                        .queryParam(CODE, code)
                         .build(true))
                 .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
                 .retrieve()
                 .onStatus(HttpStatusCode::is4xxClientError, clientResponse ->
-                        Mono.error(new CustomException(HttpStatus.BAD_GATEWAY, "Invalid Parameter")))
+                        Mono.error(new CustomException(HttpStatus.BAD_REQUEST, "Invalid Parameter")))
                 .onStatus(HttpStatusCode::is5xxServerError, clientResponse ->
                         Mono.error(new CustomException(HttpStatus.BAD_GATEWAY, "Internal Server Error")))
                 .bodyToMono(KakaoTokenResponse.class)

--- a/src/main/java/com/example/temp/user/service/oauth/kakao/KakaoTokenClient.java
+++ b/src/main/java/com/example/temp/user/service/oauth/kakao/KakaoTokenClient.java
@@ -15,11 +15,11 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 public class KakaoTokenClient {
 
-    public static final String GRANT_TYPE = "grant_type";
-    public static final String AUTHORIZATION_CODE = "authorization_code";
-    public static final String CLIENT_ID = "client_id";
-    public static final String REDIRECT_URI = "redirect_uri";
-    public static final String CODE = "code";
+    private static final String GRANT_TYPE = "grant_type";
+    private static final String AUTHORIZATION_CODE = "authorization_code";
+    private static final String CLIENT_ID = "client_id";
+    private static final String REDIRECT_URI = "redirect_uri";
+    private static final String CODE = "code";
 
     private final KakaoUrlBuilder kakaoUrlBuilder;
 

--- a/src/main/java/com/example/temp/user/service/oauth/kakao/KakaoUrlBuilder.java
+++ b/src/main/java/com/example/temp/user/service/oauth/kakao/KakaoUrlBuilder.java
@@ -1,0 +1,34 @@
+package com.example.temp.user.service.oauth.kakao;
+
+import com.example.temp.user.service.oauth.OAuthUrlBuilder;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+public class KakaoUrlBuilder implements OAuthUrlBuilder {
+
+    @Value("${oauth2.kakao.authorization-uri}")
+    private String authorizationUri;
+    @Value("${oauth2.kakao.token-uri}")
+    private String tokenUri;
+    @Value("${oauth2.kakao.profile-uri}")
+    private String profileUri;
+
+    @Value("${oauth2.kakao.client-id}")
+    private String clientId;
+    @Value("${oauth2.kakao.redirect-uri}")
+    private String redirectUri;
+    @Value("${oauth2.kakao.client-secret}")
+    private String clientSecret;
+
+    @Override
+    public String authorize() {
+        return authorizationUri
+                + "?response_type=code"
+                + "&client_id=" + clientId
+                + "&redirect_uri=" + redirectUri
+                + "&scope=openid";
+    }
+}

--- a/src/main/java/com/example/temp/user/service/oauth/kakao/KakaoUrlBuilder.java
+++ b/src/main/java/com/example/temp/user/service/oauth/kakao/KakaoUrlBuilder.java
@@ -20,8 +20,6 @@ public class KakaoUrlBuilder implements OAuthUrlBuilder {
     private String clientId;
     @Value("${oauth2.kakao.redirect-uri}")
     private String redirectUri;
-    @Value("${oauth2.kakao.client-secret}")
-    private String clientSecret;
 
     @Override
     public String authorize() {

--- a/src/main/java/com/example/temp/user/service/oauth/kakao/OAuthKakaoAdapter.java
+++ b/src/main/java/com/example/temp/user/service/oauth/kakao/OAuthKakaoAdapter.java
@@ -36,7 +36,7 @@ public class OAuthKakaoAdapter implements OAuthAdapter {
                     .platformId(profile.getId())
                     .platformType(PlatformType.KAKAO)
                     .email(profile.getKakaoAccount().getEmail())
-                    .nickname(profile.getKakaoAccount().getProfile().getNickname())
+                    .name(profile.getKakaoAccount().getProfile().getNickname())
                     .profileImageUrl(profile.getKakaoAccount().getProfile().getThumbnailImageUrl())
                     .build();
 

--- a/src/main/java/com/example/temp/user/service/oauth/kakao/OAuthKakaoAdapter.java
+++ b/src/main/java/com/example/temp/user/service/oauth/kakao/OAuthKakaoAdapter.java
@@ -36,7 +36,7 @@ public class OAuthKakaoAdapter implements OAuthAdapter {
                     .platformId(profile.getId())
                     .platformType(PlatformType.KAKAO)
                     .email(profile.getKakaoAccount().getEmail())
-                    .name(profile.getKakaoAccount().getProfile().getNickname())
+                    .nickname(profile.getKakaoAccount().getProfile().getNickname())
                     .profileImageUrl(profile.getKakaoAccount().getProfile().getThumbnailImageUrl())
                     .build();
 

--- a/src/main/java/com/example/temp/user/service/oauth/kakao/OAuthKakaoAdapter.java
+++ b/src/main/java/com/example/temp/user/service/oauth/kakao/OAuthKakaoAdapter.java
@@ -1,6 +1,7 @@
 package com.example.temp.user.service.oauth.kakao;
 
 import com.example.temp.common.exception.CustomException;
+import com.example.temp.user.domain.value.PlatformType;
 import com.example.temp.user.service.oauth.OAuthAdapter;
 import com.example.temp.user.service.oauth.response.KakaoProfileResponse;
 import com.example.temp.user.service.oauth.response.OAuthResponse;
@@ -31,15 +32,14 @@ public class OAuthKakaoAdapter implements OAuthAdapter {
             // 프로필 조회
             KakaoProfileResponse profile = kakaoProfileClient.getProfile(accessToken);
 
-            OAuthResponse oAuthResponse = OAuthResponse.builder()
+            return OAuthResponse.builder()
                     .platformId(profile.getId())
-                    .platformType("kakao")
+                    .platformType(PlatformType.KAKAO)
                     .email(profile.getKakaoAccount().getEmail())
                     .name(profile.getKakaoAccount().getProfile().getNickname())
                     .profileImageUrl(profile.getKakaoAccount().getProfile().getThumbnailImageUrl())
                     .build();
 
-            return oAuthResponse;
         } catch (RuntimeException e) {
             throw new CustomException(HttpStatus.BAD_REQUEST, "프로필 조회에 실패했습니다");
         }

--- a/src/main/java/com/example/temp/user/service/oauth/kakao/OAuthKakaoAdapter.java
+++ b/src/main/java/com/example/temp/user/service/oauth/kakao/OAuthKakaoAdapter.java
@@ -32,7 +32,7 @@ public class OAuthKakaoAdapter implements OAuthAdapter {
             KakaoProfileResponse profile = kakaoProfileClient.getProfile(accessToken);
 
             OAuthResponse oAuthResponse = OAuthResponse.builder()
-                    .platformId(profile.getId().toString())
+                    .platformId(profile.getId())
                     .platformType("kakao")
                     .email(profile.getKakaoAccount().getEmail())
                     .name(profile.getKakaoAccount().getProfile().getNickname())

--- a/src/main/java/com/example/temp/user/service/oauth/kakao/OAuthKakaoAdapter.java
+++ b/src/main/java/com/example/temp/user/service/oauth/kakao/OAuthKakaoAdapter.java
@@ -1,0 +1,47 @@
+package com.example.temp.user.service.oauth.kakao;
+
+import com.example.temp.common.exception.CustomException;
+import com.example.temp.user.service.oauth.OAuthAdapter;
+import com.example.temp.user.service.oauth.response.KakaoProfileResponse;
+import com.example.temp.user.service.oauth.response.OAuthResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OAuthKakaoAdapter implements OAuthAdapter {
+
+    private final KakaoTokenClient kakaoTokenClient;
+    private final KakaoProfileClient kakaoProfileClient;
+
+    @Override
+    public String getToken(String code) {
+        try {
+            // 토큰 받아오기
+            return kakaoTokenClient.getAccessToken(code);
+        } catch (RuntimeException e) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, "토큰이 유효하지 않습니다");
+        }
+    }
+
+    @Override
+    public OAuthResponse getProfile(String accessToken) {
+        try {
+            // 프로필 조회
+            KakaoProfileResponse profile = kakaoProfileClient.getProfile(accessToken);
+
+            OAuthResponse oAuthResponse = OAuthResponse.builder()
+                    .platformId(profile.getId().toString())
+                    .platformType("kakao")
+                    .email(profile.getKakaoAccount().getEmail())
+                    .name(profile.getKakaoAccount().getProfile().getNickname())
+                    .profileImageUrl(profile.getKakaoAccount().getProfile().getThumbnailImageUrl())
+                    .build();
+
+            return oAuthResponse;
+        } catch (RuntimeException e) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, "프로필 조회에 실패했습니다");
+        }
+    }
+}

--- a/src/main/java/com/example/temp/user/service/oauth/response/KakaoProfileResponse.java
+++ b/src/main/java/com/example/temp/user/service/oauth/response/KakaoProfileResponse.java
@@ -1,0 +1,47 @@
+package com.example.temp.user.service.oauth.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor
+@ToString
+public class KakaoProfileResponse {
+    private Long id;
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    public KakaoProfileResponse(Long id, KakaoAccount kakaoAccount) {
+        this.id = id;
+        this.kakaoAccount = kakaoAccount;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @ToString
+    public static class KakaoAccount {
+        private String email;
+        private KakaoProfile profile;
+
+        public KakaoAccount(String email, KakaoProfile profile) {
+            this.email = email;
+            this.profile = profile;
+        }
+
+        @Getter
+        @NoArgsConstructor
+        @ToString
+        public static class KakaoProfile {
+            private String nickname;
+            @JsonProperty("thumbnail_image_url")
+            private String thumbnailImageUrl;
+
+            public KakaoProfile(String nickname, String thumbnailImageUrl) {
+                this.nickname = nickname;
+                this.thumbnailImageUrl = thumbnailImageUrl;
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/temp/user/service/oauth/response/KakaoTokenResponse.java
+++ b/src/main/java/com/example/temp/user/service/oauth/response/KakaoTokenResponse.java
@@ -1,0 +1,27 @@
+package com.example.temp.user.service.oauth.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor
+@ToString
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoTokenResponse {
+    @JsonProperty("token_type")
+    public String tokenType;
+    @JsonProperty("access_token")
+    public String accessToken;
+    @JsonProperty("id_token")
+    public String idToken;
+    @JsonProperty("expires_in")
+    public Integer expiresIn;
+    @JsonProperty("refresh_token")
+    public String refreshToken;
+    @JsonProperty("refresh_token_expires_in")
+    public Integer refreshTokenExpiresIn;
+    public String scope;
+}

--- a/src/main/java/com/example/temp/user/service/oauth/response/OAuthResponse.java
+++ b/src/main/java/com/example/temp/user/service/oauth/response/OAuthResponse.java
@@ -13,15 +13,15 @@ public class OAuthResponse {
     private Long platformId;
     private PlatformType platformType;
     private String email;
-    private String nickname;
+    private String name; // kakao response에선 nickname
     private String profileImageUrl;
 
     @Builder
-    private OAuthResponse(Long platformId, PlatformType platformType, String email, String nickname, String profileImageUrl) {
+    private OAuthResponse(Long platformId, PlatformType platformType, String email, String name, String profileImageUrl) {
         this.platformId = platformId;
         this.platformType = platformType;
         this.email = email;
-        this.nickname = nickname;
+        this.name = name;
         this.profileImageUrl = profileImageUrl;
     }
 }

--- a/src/main/java/com/example/temp/user/service/oauth/response/OAuthResponse.java
+++ b/src/main/java/com/example/temp/user/service/oauth/response/OAuthResponse.java
@@ -13,15 +13,15 @@ public class OAuthResponse {
     private Long platformId;
     private PlatformType platformType;
     private String email;
-    private String name;
+    private String nickname;
     private String profileImageUrl;
 
     @Builder
-    private OAuthResponse(Long platformId, PlatformType platformType, String email, String name, String profileImageUrl) {
+    private OAuthResponse(Long platformId, PlatformType platformType, String email, String nickname, String profileImageUrl) {
         this.platformId = platformId;
         this.platformType = platformType;
         this.email = email;
-        this.name = name;
+        this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;
     }
 }

--- a/src/main/java/com/example/temp/user/service/oauth/response/OAuthResponse.java
+++ b/src/main/java/com/example/temp/user/service/oauth/response/OAuthResponse.java
@@ -9,14 +9,14 @@ import lombok.ToString;
 @NoArgsConstructor
 @ToString
 public class OAuthResponse {
-    private String platformId;
+    private Long platformId;
     private String platformType;
     private String email;
     private String name;
     private String profileImageUrl;
 
     @Builder
-    private OAuthResponse(String platformId, String platformType, String email, String name, String profileImageUrl) {
+    private OAuthResponse(Long platformId, String platformType, String email, String name, String profileImageUrl) {
         this.platformId = platformId;
         this.platformType = platformType;
         this.email = email;

--- a/src/main/java/com/example/temp/user/service/oauth/response/OAuthResponse.java
+++ b/src/main/java/com/example/temp/user/service/oauth/response/OAuthResponse.java
@@ -1,0 +1,26 @@
+package com.example.temp.user.service.oauth.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor
+@ToString
+public class OAuthResponse {
+    private String platformId;
+    private String platformType;
+    private String email;
+    private String name;
+    private String profileImageUrl;
+
+    @Builder
+    private OAuthResponse(String platformId, String platformType, String email, String name, String profileImageUrl) {
+        this.platformId = platformId;
+        this.platformType = platformType;
+        this.email = email;
+        this.name = name;
+        this.profileImageUrl = profileImageUrl;
+    }
+}

--- a/src/main/java/com/example/temp/user/service/oauth/response/OAuthResponse.java
+++ b/src/main/java/com/example/temp/user/service/oauth/response/OAuthResponse.java
@@ -1,5 +1,6 @@
 package com.example.temp.user.service.oauth.response;
 
+import com.example.temp.user.domain.value.PlatformType;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,13 +11,13 @@ import lombok.ToString;
 @ToString
 public class OAuthResponse {
     private Long platformId;
-    private String platformType;
+    private PlatformType platformType;
     private String email;
     private String name;
     private String profileImageUrl;
 
     @Builder
-    private OAuthResponse(Long platformId, String platformType, String email, String name, String profileImageUrl) {
+    private OAuthResponse(Long platformId, PlatformType platformType, String email, String name, String profileImageUrl) {
         this.platformId = platformId;
         this.platformType = platformType;
         this.email = email;


### PR DESCRIPTION
### 기능 구현
- 회원가입 및 로그인 구현
  - 이름, 닉네임과 프로필 사진은 정책이 정확하지 않아서 일단 냅둠
- JWT access token, refresh token(관련 기능 아직 없음) 발급
- 필터로 인가 관리
  - 인가관련 Exception에 따른 커스텀 필요 (현재 500에러)

토큰 유효O
![스크린샷 2024-07-26 140056](https://github.com/user-attachments/assets/cb5aa2ee-0d0d-4125-b4ea-a936dcf66d9d)

토큰 유효X
![image](https://github.com/user-attachments/assets/1d6bf97a-008c-49d4-ae7a-9344a61a05e3)

### 추가사항
- FindUserProfileServiceImpl 수정
  - 회원 중복 확인을 eamil로 확인하도록
- UserProfileView 이거 이렇게 쓰는 거 맞는지 확인 좀 ㅎ;;



