### PR TITLE
JWT 유효성 검증 메서드 로직 오류 정정

### DIFF
--- a/src/main/java/com/example/temp/user/service/impl/JwtTokenService.java
+++ b/src/main/java/com/example/temp/user/service/impl/JwtTokenService.java
@@ -5,7 +5,6 @@ import com.example.temp.user.domain.User;
 import com.example.temp.user.dto.JwtToken;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ClaimsBuilder;
-import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -21,7 +20,6 @@ import java.util.Base64;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Function;
 
 @Service
 @RequiredArgsConstructor
@@ -120,41 +118,13 @@ public class JwtTokenService {
                 .compact();
     }
 
-
-    /*
-     *   Token 검증
-     */
     public boolean isTokenValid(String token) {
-        Claims claims = extractAllClaims(token);
-
         try {
-            if (!claims.containsKey(ROLE_CLAIM)) return false;
-            if (!claims.containsKey(IDENTIFICATION_CLAIM)) return false;
-        } catch (RuntimeException e) { // covered for NullPointException, IllegalArgumentException
-            throw new JwtException("잘못된 정보입니다");
+            extractAllClaims(token);
+        } catch (Exception e) {
+            return false;
         }
-
-        String claimsSubject = claims.getSubject();
-
-        return !isTokenExpired(token);
-    }
-
-    private boolean isTokenExpired(String token) {
-        return extractExpiration(token).before(new Date());
-    }
-
-
-    /*
-     *   Token 정보 추출
-     */
-    private <T> T extractClaim(String token, Function<Claims, T> claimsResolver) {
-        Claims claims = extractAllClaims(token);
-
-        return claimsResolver.apply(claims);
-    }
-
-    private Date extractExpiration(String token) {
-        return extractClaim(token, Claims::getExpiration);
+        return true;
     }
 
     private Claims extractAllClaims(String token) {


### PR DESCRIPTION
### 관련 이슈
- close #7  

### 작업 내용
- 유효하지 않은 토큰(만료된 토큰, 날조된 토큰 등)의 경우 클레임 추출 과정에서 예외가 발생하여 false를 정상적으로 반환하지 못하는 문제 해결

- 토큰 생성 시점에 Role 및 Identification 클레임을 제대로 설정했고 이후 복호화에 성공했다면, 해당 클레임들은 반드시 존재하므로 이에 대한 검증 로직은 생략