### PR TITLE
경기장 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/example/temp/baseball/controller/StadiumController.java
+++ b/src/main/java/com/example/temp/baseball/controller/StadiumController.java
@@ -1,0 +1,28 @@
+package com.example.temp.baseball.controller;
+
+import com.example.temp.baseball.dto.FindStadiumListResponse;
+import com.example.temp.baseball.dto.StadiumView;
+import com.example.temp.baseball.service.FindAllStadiumsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/baseball/stadium")
+public class StadiumController {
+
+    private final FindAllStadiumsService findAllStadiumsService;
+
+    @GetMapping("/list")
+    public ResponseEntity<FindStadiumListResponse> findStadiumList() {
+        List<StadiumView> stadiumViews = findAllStadiumsService.doService();
+        FindStadiumListResponse response = new FindStadiumListResponse(stadiumViews);
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/com/example/temp/baseball/domain/Stadium.java
+++ b/src/main/java/com/example/temp/baseball/domain/Stadium.java
@@ -1,23 +1,25 @@
 package com.example.temp.baseball.domain;
 
 import com.example.temp.geo.entity.Address;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Stadium {
+
     @Id
     private Long id;
+
     @ManyToOne(fetch = FetchType.LAZY)
     private Address address;
-    private String aliasAddr;
+
+    // 경기장 줄임말 (예시: 잠실종합운동장잠실야구장 -> 잠실)
+    @Column(nullable = false)
+    private String shortenName;
 
     public String getStadiumName() {
         return address.getBuildName();

--- a/src/main/java/com/example/temp/baseball/domain/StadiumRepository.java
+++ b/src/main/java/com/example/temp/baseball/domain/StadiumRepository.java
@@ -2,5 +2,9 @@ package com.example.temp.baseball.domain;
 
 import org.springframework.data.repository.Repository;
 
+import java.util.List;
+
 public interface StadiumRepository extends Repository<Stadium, Long> {
+
+    List<Stadium> findAll();
 }

--- a/src/main/java/com/example/temp/baseball/dto/FindStadiumListResponse.java
+++ b/src/main/java/com/example/temp/baseball/dto/FindStadiumListResponse.java
@@ -1,0 +1,6 @@
+package com.example.temp.baseball.dto;
+
+import java.util.List;
+
+public record FindStadiumListResponse(List<StadiumView> stadiums) {
+}

--- a/src/main/java/com/example/temp/baseball/dto/StadiumView.java
+++ b/src/main/java/com/example/temp/baseball/dto/StadiumView.java
@@ -1,0 +1,13 @@
+package com.example.temp.baseball.dto;
+
+import com.example.temp.baseball.domain.Stadium;
+import com.example.temp.geo.dto.AddressInformationView;
+
+public record StadiumView(String shortenName, AddressInformationView address) {
+
+    public static StadiumView of(Stadium stadium) {
+        return new StadiumView(
+                stadium.getShortenName(),
+                AddressInformationView.of(stadium.getAddress()));
+    }
+}

--- a/src/main/java/com/example/temp/baseball/dto/TeamInformationView.java
+++ b/src/main/java/com/example/temp/baseball/dto/TeamInformationView.java
@@ -15,7 +15,7 @@ public record TeamInformationView(
                 team.getName(),
                 team.getRepresentativeImageUrl(),
                 team.getStadium().getStadiumName(),
-                team.getStadium().getAliasAddr()
+                team.getStadium().getShortenName()
         );
     }
 }

--- a/src/main/java/com/example/temp/baseball/service/FindAllStadiumsService.java
+++ b/src/main/java/com/example/temp/baseball/service/FindAllStadiumsService.java
@@ -1,0 +1,10 @@
+package com.example.temp.baseball.service;
+
+import com.example.temp.baseball.dto.StadiumView;
+
+import java.util.List;
+
+public interface FindAllStadiumsService {
+
+    List<StadiumView> doService();
+}

--- a/src/main/java/com/example/temp/baseball/service/impl/FindAllStadiumsServiceImpl.java
+++ b/src/main/java/com/example/temp/baseball/service/impl/FindAllStadiumsServiceImpl.java
@@ -1,0 +1,26 @@
+package com.example.temp.baseball.service.impl;
+
+import com.example.temp.baseball.domain.StadiumRepository;
+import com.example.temp.baseball.dto.StadiumView;
+import com.example.temp.baseball.service.FindAllStadiumsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FindAllStadiumsServiceImpl implements FindAllStadiumsService {
+
+    private final StadiumRepository stadiumRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<StadiumView> doService() {
+        return stadiumRepository.findAll()
+                .stream()
+                .map(StadiumView::of)
+                .toList();
+    }
+}

--- a/src/main/java/com/example/temp/geo/dto/AddressInformationView.java
+++ b/src/main/java/com/example/temp/geo/dto/AddressInformationView.java
@@ -15,4 +15,16 @@ public record AddressInformationView(
     public AddressInformationView(Address address) {
         this(address.getFullText(), address.getZipNo(), address.getSido(), address.getSigungu(), address.getDong(), address.getDongCd(), address.getX(), address.getY());
     }
+
+    public static AddressInformationView of(Address address) {
+        return new AddressInformationView(
+                address.getFullText(),
+                address.getZipNo(),
+                address.getSido(),
+                address.getSigungu(),
+                address.getDong(),
+                address.getDongCd(),
+                address.getX(),
+                address.getY());
+    }
 }


### PR DESCRIPTION
## 내용
- 경기장 목록 조회 API 구현
- 경기장 엔티티 '줄임말' 속성명 변경 및 예시 주석 추가: aliasAddr -> shortenName
- 경기장 엔티티 코드 들여쓰기 개선