### PR TITLE
위치 기반 관광 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/example/temp/tour/controller/TourController.java
+++ b/src/main/java/com/example/temp/tour/controller/TourController.java
@@ -1,0 +1,35 @@
+package com.example.temp.tour.controller;
+
+import com.example.temp.tour.dto.FindTourInformationByLocationCommand;
+import com.example.temp.tour.dto.FindTourInformationResponse;
+import com.example.temp.tour.service.FindTourInformationByLocationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/tour")
+public class TourController {
+
+    private final FindTourInformationByLocationService findTourInformationByLocationService;
+
+    @GetMapping("/info")
+    public ResponseEntity<FindTourInformationResponse> findTourInformation(
+            @RequestParam(name = "pageSize") int pageSize,
+            @RequestParam(name = "pageNumber") int pageNumber,
+            @RequestParam(name = "x") String x,
+            @RequestParam(name = "y") String y,
+            @RequestParam(name = "radius") String radius,
+            @RequestParam(name = "contentType") String contentTypeId
+    ) {
+        FindTourInformationByLocationCommand command = new FindTourInformationByLocationCommand(
+                pageSize, pageNumber, x, y, radius, contentTypeId);
+        FindTourInformationResponse response = findTourInformationByLocationService.doService(command);
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/com/example/temp/tour/dto/FindTourInformationByLocationCommand.java
+++ b/src/main/java/com/example/temp/tour/dto/FindTourInformationByLocationCommand.java
@@ -1,8 +1,8 @@
 package com.example.temp.tour.dto;
 
 public record FindTourInformationByLocationCommand(
-        int numOfRows,
-        int pageNo,
+        int pageSize,
+        int pageNumber,
         String x,
         String y,
         String radius,

--- a/src/main/java/com/example/temp/tour/dto/FindTourInformationByLocationHttpResponse.java
+++ b/src/main/java/com/example/temp/tour/dto/FindTourInformationByLocationHttpResponse.java
@@ -73,6 +73,8 @@ public class FindTourInformationByLocationHttpResponse {
                 public static class Item {
                     private int totalCnt;
 
+                    @JsonProperty("contentid")
+                    private String contentId;
                     @JsonProperty("contenttypeid")
                     private String contentTypeId;
                     private String areacode;

--- a/src/main/java/com/example/temp/tour/dto/FindTourInformationResponse.java
+++ b/src/main/java/com/example/temp/tour/dto/FindTourInformationResponse.java
@@ -6,7 +6,7 @@ public record FindTourInformationResponse(
         int pageSize,
         int pageNumber,
         int totalCount,
-        List<TourInformation> tourInformation
+        List<TourInformationSummary> items
 ) {
 
     public static FindTourInformationResponse of(FindTourInformationByLocationHttpResponse response) {
@@ -14,31 +14,20 @@ public record FindTourInformationResponse(
                 response.getNumOfRows(),
                 response.getPageNo(),
                 response.getTotalCount(),
-                extractTourInformation(response)
+                extractTourInformationItems(response)
         );
     }
 
-    private static List<TourInformation> extractTourInformation(FindTourInformationByLocationHttpResponse response) {
+    private static List<TourInformationSummary> extractTourInformationItems(FindTourInformationByLocationHttpResponse response) {
         return response.getItems()
                 .stream()
-                .map(item -> TourInformation.builder()
-                        .addr1(item.getAddr1())
-                        .addr2(item.getAddr2())
-                        .cat1(item.getCat1())
-                        .cat2(item.getCat2())
-                        .cat3(item.getCat3())
-                        .sigunguCode(item.getSigungucode())
-                        .areaCode(item.getAreacode())
-                        .contentTypeId(item.getContentTypeId())
-                        // .createdTime(i.getCreatedTime())
-                        // .modifiedTime(i.getModifiedTime())
-                        .representativeImageUrl(item.getRepresentativeImageUrl())
-                        .thumbnail(item.getThumbnail())
-                        .x(item.getX())
-                        .y(item.getY())
-                        .tel(item.getTel())
+                .map(item -> TourInformationSummary.builder()
                         .title(item.getTitle())
-                        .dist(item.getDist())
+                        .thumbnail(item.getThumbnail())
+                        .address(item.getAddr1())
+                        .distance(item.getDist())
+                        .contentId(item.getContentId())
+                        .contentType(item.getContentTypeId())
                         .build()
                 )
                 .toList();

--- a/src/main/java/com/example/temp/tour/dto/FindTourInformationResponse.java
+++ b/src/main/java/com/example/temp/tour/dto/FindTourInformationResponse.java
@@ -3,8 +3,8 @@ package com.example.temp.tour.dto;
 import java.util.List;
 
 public record FindTourInformationResponse(
-        int numOfRows,
-        int pageNo,
+        int pageSize,
+        int pageNumber,
         int totalCount,
         List<TourInformation> tourInformation
 ) {

--- a/src/main/java/com/example/temp/tour/dto/FindTourInformationResponse.java
+++ b/src/main/java/com/example/temp/tour/dto/FindTourInformationResponse.java
@@ -2,15 +2,15 @@ package com.example.temp.tour.dto;
 
 import java.util.List;
 
-public record FindTourInformationResult(
+public record FindTourInformationResponse(
         int numOfRows,
         int pageNo,
         int totalCount,
         List<TourInformation> tourInformation
 ) {
 
-    public static FindTourInformationResult of(FindTourInformationByLocationHttpResponse response) {
-        return new FindTourInformationResult(
+    public static FindTourInformationResponse of(FindTourInformationByLocationHttpResponse response) {
+        return new FindTourInformationResponse(
                 response.getNumOfRows(),
                 response.getPageNo(),
                 response.getTotalCount(),

--- a/src/main/java/com/example/temp/tour/dto/FindTourInformationResult.java
+++ b/src/main/java/com/example/temp/tour/dto/FindTourInformationResult.java
@@ -1,23 +1,26 @@
 package com.example.temp.tour.dto;
 
-import lombok.Getter;
-
 import java.util.List;
 
-@Getter
-public class FindTourInformationResult {
+public record FindTourInformationResult(
+        int numOfRows,
+        int pageNo,
+        int totalCount,
+        List<TourInformation> tourInformation
+) {
 
-    private final int numOfRows;
-    private final int pageNo;
-    private final int totalCount;
-    private final List<TourInformation> tourInformation;
+    public static FindTourInformationResult of(FindTourInformationByLocationHttpResponse response) {
+        return new FindTourInformationResult(
+                response.getNumOfRows(),
+                response.getPageNo(),
+                response.getTotalCount(),
+                extractTourInformation(response)
+        );
+    }
 
-    public FindTourInformationResult(FindTourInformationByLocationHttpResponse response) {
-        this.numOfRows = response.getNumOfRows();
-        this.pageNo = response.getPageNo();
-        this.totalCount = response.getTotalCount();
-
-        this.tourInformation = response.getItems().stream()
+    private static List<TourInformation> extractTourInformation(FindTourInformationByLocationHttpResponse response) {
+        return response.getItems()
+                .stream()
                 .map(item -> TourInformation.builder()
                         .addr1(item.getAddr1())
                         .addr2(item.getAddr2())

--- a/src/main/java/com/example/temp/tour/dto/FindTourInformationResult.java
+++ b/src/main/java/com/example/temp/tour/dto/FindTourInformationResult.java
@@ -1,9 +1,7 @@
 package com.example.temp.tour.dto;
 
-import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -14,78 +12,32 @@ public class FindTourInformationResult {
     private final int totalCount;
     private final List<TourInformation> tourInformation;
 
-    @Getter
-    private static class TourInformation {
-        private final String contentTypeId;
-        private final String areaCode;
-        private final String sigunguCode;
+    public FindTourInformationResult(FindTourInformationByLocationHttpResponse response) {
+        this.numOfRows = response.getNumOfRows();
+        this.pageNo = response.getPageNo();
+        this.totalCount = response.getTotalCount();
 
-        private final String cat1; // 대분류
-        private final String cat2; // 중분류
-        private final String cat3; // 소분류
-        private final String addr1;   // 주소 전체
-        private final String addr2; // 상세주소
-
-        private final String representativeImageUrl;  // 대표이미지
-        private final String thumbnail; // 썸네일 이미지
-        private final String x;
-        private final String y;
-
-        private final String dist; // 거리
-        private final String tel;
-        private final String title;
-
-        private final LocalDateTime createdTime;
-        private final LocalDateTime modifiedTime;
-
-        @Builder
-        public TourInformation(String contentTypeId, String areaCode, String sigunguCode, String cat1, String cat2, String cat3, String addr1, String addr2, String representativeImageUrl, String thumbnail, String x, String y, String dist, String tel, String title, LocalDateTime createdTime, LocalDateTime modifiedTime) {
-            this.contentTypeId = contentTypeId;
-            this.areaCode = areaCode;
-            this.sigunguCode = sigunguCode;
-            this.cat1 = cat1;
-            this.cat2 = cat2;
-            this.cat3 = cat3;
-            this.addr1 = addr1;
-            this.addr2 = addr2;
-            this.representativeImageUrl = representativeImageUrl;
-            this.thumbnail = thumbnail;
-            this.x = x;
-            this.y = y;
-            this.dist = dist;
-            this.tel = tel;
-            this.title = title;
-            this.createdTime = createdTime;
-            this.modifiedTime = modifiedTime;
-        }
-    }
-
-    public FindTourInformationResult(FindTourInformationByLocationHttpResponse res) {
-        this.numOfRows = res.getNumOfRows();
-        this.pageNo = res.getPageNo();
-        this.totalCount = res.getTotalCount();
-
-        this.tourInformation = res.getItems().stream()
-                .map(i -> TourInformation.builder()
-                        .addr1(i.getAddr1())
-                        .addr2(i.getAddr2())
-                        .cat1(i.getCat1())
-                        .cat2(i.getCat2())
-                        .cat3(i.getCat3())
-                        .sigunguCode(i.getSigungucode())
-                        .areaCode(i.getAreacode())
-                        .contentTypeId(i.getContentTypeId())
+        this.tourInformation = response.getItems().stream()
+                .map(item -> TourInformation.builder()
+                        .addr1(item.getAddr1())
+                        .addr2(item.getAddr2())
+                        .cat1(item.getCat1())
+                        .cat2(item.getCat2())
+                        .cat3(item.getCat3())
+                        .sigunguCode(item.getSigungucode())
+                        .areaCode(item.getAreacode())
+                        .contentTypeId(item.getContentTypeId())
                         // .createdTime(i.getCreatedTime())
                         // .modifiedTime(i.getModifiedTime())
-                        .representativeImageUrl(i.getRepresentativeImageUrl())
-                        .thumbnail(i.getThumbnail())
-                        .x(i.getX())
-                        .y(i.getY())
-                        .tel(i.getTel())
-                        .title(i.getTitle())
-                        .dist(i.getDist())
+                        .representativeImageUrl(item.getRepresentativeImageUrl())
+                        .thumbnail(item.getThumbnail())
+                        .x(item.getX())
+                        .y(item.getY())
+                        .tel(item.getTel())
+                        .title(item.getTitle())
+                        .dist(item.getDist())
                         .build()
-                ).toList();
-
+                )
+                .toList();
     }
 }

--- a/src/main/java/com/example/temp/tour/dto/TourInformation.java
+++ b/src/main/java/com/example/temp/tour/dto/TourInformation.java
@@ -1,0 +1,27 @@
+package com.example.temp.tour.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record TourInformation(
+        String contentTypeId,
+        String areaCode,
+        String sigunguCode,
+        String cat1,
+        String cat2,
+        String cat3,
+        String addr1,
+        String addr2,
+        String representativeImageUrl,
+        String thumbnail,
+        String x,
+        String y,
+        String dist,
+        String tel,
+        String title,
+        LocalDateTime createdTime,
+        LocalDateTime modifiedTime
+) {
+}

--- a/src/main/java/com/example/temp/tour/dto/TourInformationSummary.java
+++ b/src/main/java/com/example/temp/tour/dto/TourInformationSummary.java
@@ -1,0 +1,14 @@
+package com.example.temp.tour.dto;
+
+import lombok.Builder;
+
+@Builder
+public record TourInformationSummary(
+        String title,
+        String address,
+        String thumbnail,
+        String distance,
+        String contentId,
+        String contentType
+) {
+}

--- a/src/main/java/com/example/temp/tour/service/FindTourInformationByLocationService.java
+++ b/src/main/java/com/example/temp/tour/service/FindTourInformationByLocationService.java
@@ -1,81 +1,9 @@
 package com.example.temp.tour.service;
 
-import com.example.temp.common.exception.CustomException;
 import com.example.temp.tour.dto.FindTourInformationByLocationCommand;
-import com.example.temp.tour.dto.FindTourInformationByLocationHttpResponse;
 import com.example.temp.tour.dto.FindTourInformationResult;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
-import org.springframework.stereotype.Component;
-import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.util.UriComponentsBuilder;
-import reactor.core.publisher.Mono;
 
-import java.net.URI;
+public interface FindTourInformationByLocationService {
 
-@Component
-@Slf4j
-public class FindTourInformationByLocationService {
-
-    public static final String NUM_OF_ROWS_PARAM = "numOfRows";
-    public static final String PAGE_NO_PARAM = "pageNo";
-    public static final String MOBILE_OS_PARAM = "MobileOS"; // required
-    public static final String MOBILE_OS_PARAM_VALUE = "WEB"; // required
-    public static final String MOBILE_APP_PARAM = "MobileApp"; // required
-    public static final String MOBILE_APP_PARAM_VALUE = "fanpool"; // required
-    public static final String TYPE_PARAM = "_type";
-    public static final String TYPE_PARAM_VALUE = "json";
-    public static final String LIST_YN_PARAM = "listYN";
-    public static final String LIST_YN_PARAM_VALUE_Y = "Y";
-    public static final String LIST_YN_PARAM_VALUE_N = "N";
-    // 정렬구분 (A=제목순, C=수정일순, D=생성일순) 대표이미지가반드시있는정렬(O=제목순, Q=수정일순, R=생성일순)
-    public static final String ARRANGE_PARAM = "arrange";
-    public static final String MAP_X_PARAM = "mapX"; // required
-    public static final String MAP_Y_PARAM = "mapY"; //required
-    public static final String RADIUS_PARAM = "radius"; //required
-    public static final String CONTENT_TYPE_ID_PARAM = "contentTypeId";
-    public static final String MODIFIED_TIME_PARAM = "modifiedtime";
-    public static final String SERVICE_KEY_PARAM = "serviceKey"; //required
-
-
-    @Value("${tour.knto.rest-api-key}")
-    private String restApiKey;
-    @Value("${tour.knto.info-kor.base-url}")
-    private String baseUrl;
-    @Value("${tour.knto.info-kor.location-based-list-uri}")
-    private String locationBasedListUri;
-
-    public FindTourInformationResult get(FindTourInformationByLocationCommand command) {
-        URI uri = UriComponentsBuilder.fromHttpUrl(baseUrl)
-                .path(locationBasedListUri)
-                .queryParam(SERVICE_KEY_PARAM, restApiKey)
-                .queryParam(MOBILE_OS_PARAM, MOBILE_OS_PARAM_VALUE)
-                .queryParam(MOBILE_APP_PARAM, MOBILE_APP_PARAM_VALUE)
-                .queryParam(MAP_X_PARAM, command.x())
-                .queryParam(MAP_Y_PARAM, command.y())
-                .queryParam(RADIUS_PARAM, command.radius()) // 여기까지 필수
-                .queryParam(NUM_OF_ROWS_PARAM, command.numOfRows())
-                .queryParam(PAGE_NO_PARAM, command.pageNo())
-                .queryParam(CONTENT_TYPE_ID_PARAM, command.contentTypeId())
-                .queryParam(TYPE_PARAM, TYPE_PARAM_VALUE)
-                .build(true)
-                .toUri();
-
-        FindTourInformationByLocationHttpResponse result = getBlock(uri);
-        return new FindTourInformationResult(result);
-    }
-
-    private FindTourInformationByLocationHttpResponse getBlock(URI uri) {
-        return WebClient.create().get()
-                .uri(uri)
-                .retrieve()
-                .onStatus(HttpStatusCode::is4xxClientError, clientResponse ->
-                        Mono.error(new CustomException(HttpStatus.BAD_REQUEST, "Invalid Parameter")))
-                .onStatus(HttpStatusCode::is5xxServerError, clientResponse ->
-                        Mono.error(new CustomException(HttpStatus.BAD_GATEWAY, "Internal Server Error")))
-                .bodyToMono(FindTourInformationByLocationHttpResponse.class)
-                .block();
-    }
+    FindTourInformationResult doService(FindTourInformationByLocationCommand command);
 }

--- a/src/main/java/com/example/temp/tour/service/FindTourInformationByLocationService.java
+++ b/src/main/java/com/example/temp/tour/service/FindTourInformationByLocationService.java
@@ -1,9 +1,9 @@
 package com.example.temp.tour.service;
 
 import com.example.temp.tour.dto.FindTourInformationByLocationCommand;
-import com.example.temp.tour.dto.FindTourInformationResult;
+import com.example.temp.tour.dto.FindTourInformationResponse;
 
 public interface FindTourInformationByLocationService {
 
-    FindTourInformationResult doService(FindTourInformationByLocationCommand command);
+    FindTourInformationResponse doService(FindTourInformationByLocationCommand command);
 }

--- a/src/main/java/com/example/temp/tour/service/FindTourInformationByLocationServiceImpl.java
+++ b/src/main/java/com/example/temp/tour/service/FindTourInformationByLocationServiceImpl.java
@@ -1,0 +1,78 @@
+package com.example.temp.tour.service;
+
+import com.example.temp.common.exception.CustomException;
+import com.example.temp.tour.dto.FindTourInformationByLocationCommand;
+import com.example.temp.tour.dto.FindTourInformationByLocationHttpResponse;
+import com.example.temp.tour.dto.FindTourInformationResult;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+
+@Service
+public class FindTourInformationByLocationServiceImpl implements FindTourInformationByLocationService {
+
+    private static final String NUM_OF_ROWS_PARAM = "numOfRows";
+    private static final String PAGE_NO_PARAM = "pageNo";
+    private static final String MOBILE_OS_PARAM = "MobileOS"; // required
+    private static final String MOBILE_OS_PARAM_VALUE = "WEB"; // required
+    private static final String MOBILE_APP_PARAM = "MobileApp"; // required
+    private static final String MOBILE_APP_PARAM_VALUE = "fanpool"; // required
+    private static final String TYPE_PARAM = "_type";
+    private static final String TYPE_PARAM_VALUE = "json";
+    private static final String LIST_YN_PARAM = "listYN";
+    private static final String LIST_YN_PARAM_VALUE_Y = "Y";
+    private static final String LIST_YN_PARAM_VALUE_N = "N";
+    // 정렬구분 (A=제목순, C=수정일순, D=생성일순) 대표이미지가반드시있는정렬(O=제목순, Q=수정일순, R=생성일순)
+    private static final String ARRANGE_PARAM = "arrange";
+    private static final String MAP_X_PARAM = "mapX"; // required
+    private static final String MAP_Y_PARAM = "mapY"; //required
+    private static final String RADIUS_PARAM = "radius"; //required
+    private static final String CONTENT_TYPE_ID_PARAM = "contentTypeId";
+    private static final String MODIFIED_TIME_PARAM = "modifiedtime";
+    private static final String SERVICE_KEY_PARAM = "serviceKey"; //required
+
+    @Value("${tour.knto.rest-api-key}")
+    private String restApiKey;
+    @Value("${tour.knto.info-kor.base-url}")
+    private String baseUrl;
+    @Value("${tour.knto.info-kor.location-based-list-uri}")
+    private String locationBasedListUri;
+
+    public FindTourInformationResult doService(FindTourInformationByLocationCommand command) {
+        URI uri = UriComponentsBuilder.fromHttpUrl(baseUrl)
+                .path(locationBasedListUri)
+                .queryParam(SERVICE_KEY_PARAM, restApiKey)
+                .queryParam(MOBILE_OS_PARAM, MOBILE_OS_PARAM_VALUE)
+                .queryParam(MOBILE_APP_PARAM, MOBILE_APP_PARAM_VALUE)
+                .queryParam(MAP_X_PARAM, command.x())
+                .queryParam(MAP_Y_PARAM, command.y())
+                .queryParam(RADIUS_PARAM, command.radius()) // 여기까지 필수
+                .queryParam(NUM_OF_ROWS_PARAM, command.numOfRows())
+                .queryParam(PAGE_NO_PARAM, command.pageNo())
+                .queryParam(CONTENT_TYPE_ID_PARAM, command.contentTypeId())
+                .queryParam(TYPE_PARAM, TYPE_PARAM_VALUE)
+                .build(true)
+                .toUri();
+
+        FindTourInformationByLocationHttpResponse result = getBlock(uri);
+        return new FindTourInformationResult(result);
+    }
+
+    private FindTourInformationByLocationHttpResponse getBlock(URI uri) {
+        return WebClient.create().get()
+                .uri(uri)
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, clientResponse ->
+                        Mono.error(new CustomException(HttpStatus.BAD_REQUEST, "Invalid Parameter")))
+                .onStatus(HttpStatusCode::is5xxServerError, clientResponse ->
+                        Mono.error(new CustomException(HttpStatus.BAD_GATEWAY, "Internal Server Error")))
+                .bodyToMono(FindTourInformationByLocationHttpResponse.class)
+                .block();
+    }
+}

--- a/src/main/java/com/example/temp/tour/service/FindTourInformationByLocationServiceImpl.java
+++ b/src/main/java/com/example/temp/tour/service/FindTourInformationByLocationServiceImpl.java
@@ -53,8 +53,8 @@ public class FindTourInformationByLocationServiceImpl implements FindTourInforma
                 .queryParam(MAP_X_PARAM, command.x())
                 .queryParam(MAP_Y_PARAM, command.y())
                 .queryParam(RADIUS_PARAM, command.radius()) // 여기까지 필수
-                .queryParam(NUM_OF_ROWS_PARAM, command.numOfRows())
-                .queryParam(PAGE_NO_PARAM, command.pageNo())
+                .queryParam(NUM_OF_ROWS_PARAM, command.pageSize())
+                .queryParam(PAGE_NO_PARAM, command.pageNumber())
                 .queryParam(CONTENT_TYPE_ID_PARAM, command.contentTypeId())
                 .queryParam(TYPE_PARAM, TYPE_PARAM_VALUE)
                 .build(true)

--- a/src/main/java/com/example/temp/tour/service/FindTourInformationByLocationServiceImpl.java
+++ b/src/main/java/com/example/temp/tour/service/FindTourInformationByLocationServiceImpl.java
@@ -60,8 +60,8 @@ public class FindTourInformationByLocationServiceImpl implements FindTourInforma
                 .build(true)
                 .toUri();
 
-        FindTourInformationByLocationHttpResponse result = getBlock(uri);
-        return new FindTourInformationResult(result);
+        FindTourInformationByLocationHttpResponse response = getBlock(uri);
+        return FindTourInformationResult.of(response);
     }
 
     private FindTourInformationByLocationHttpResponse getBlock(URI uri) {

--- a/src/main/java/com/example/temp/tour/service/FindTourInformationByLocationServiceImpl.java
+++ b/src/main/java/com/example/temp/tour/service/FindTourInformationByLocationServiceImpl.java
@@ -3,7 +3,7 @@ package com.example.temp.tour.service;
 import com.example.temp.common.exception.CustomException;
 import com.example.temp.tour.dto.FindTourInformationByLocationCommand;
 import com.example.temp.tour.dto.FindTourInformationByLocationHttpResponse;
-import com.example.temp.tour.dto.FindTourInformationResult;
+import com.example.temp.tour.dto.FindTourInformationResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
@@ -44,7 +44,7 @@ public class FindTourInformationByLocationServiceImpl implements FindTourInforma
     @Value("${tour.knto.info-kor.location-based-list-uri}")
     private String locationBasedListUri;
 
-    public FindTourInformationResult doService(FindTourInformationByLocationCommand command) {
+    public FindTourInformationResponse doService(FindTourInformationByLocationCommand command) {
         URI uri = UriComponentsBuilder.fromHttpUrl(baseUrl)
                 .path(locationBasedListUri)
                 .queryParam(SERVICE_KEY_PARAM, restApiKey)
@@ -61,7 +61,7 @@ public class FindTourInformationByLocationServiceImpl implements FindTourInforma
                 .toUri();
 
         FindTourInformationByLocationHttpResponse response = getBlock(uri);
-        return FindTourInformationResult.of(response);
+        return FindTourInformationResponse.of(response);
     }
 
     private FindTourInformationByLocationHttpResponse getBlock(URI uri) {

--- a/src/main/java/com/example/temp/tour/service/impl/FindTourInformationByLocationServiceImpl.java
+++ b/src/main/java/com/example/temp/tour/service/impl/FindTourInformationByLocationServiceImpl.java
@@ -1,9 +1,10 @@
-package com.example.temp.tour.service;
+package com.example.temp.tour.service.impl;
 
 import com.example.temp.common.exception.CustomException;
 import com.example.temp.tour.dto.FindTourInformationByLocationCommand;
 import com.example.temp.tour.dto.FindTourInformationByLocationHttpResponse;
 import com.example.temp.tour.dto.FindTourInformationResponse;
+import com.example.temp.tour.service.FindTourInformationByLocationService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
@@ -28,7 +29,7 @@ public class FindTourInformationByLocationServiceImpl implements FindTourInforma
     private static final String LIST_YN_PARAM = "listYN";
     private static final String LIST_YN_PARAM_VALUE_Y = "Y";
     private static final String LIST_YN_PARAM_VALUE_N = "N";
-    // 정렬구분 (A=제목순, C=수정일순, D=생성일순) 대표이미지가반드시있는정렬(O=제목순, Q=수정일순, R=생성일순)
+    // 정렬구분 (A=제목순, C=수정일순, D=생성일순, E=거리순) 대표이미지가반드시있는정렬(O=제목순, Q=수정일순, R=생성일순, S=거리순)
     private static final String ARRANGE_PARAM = "arrange";
     private static final String MAP_X_PARAM = "mapX"; // required
     private static final String MAP_Y_PARAM = "mapY"; //required
@@ -57,6 +58,7 @@ public class FindTourInformationByLocationServiceImpl implements FindTourInforma
                 .queryParam(PAGE_NO_PARAM, command.pageNumber())
                 .queryParam(CONTENT_TYPE_ID_PARAM, command.contentTypeId())
                 .queryParam(TYPE_PARAM, TYPE_PARAM_VALUE)
+                .queryParam(ARRANGE_PARAM, "Q") // 수정일순(최신순) 조회
                 .build(true)
                 .toUri();
 


### PR DESCRIPTION
### 위치 기반 관광 정보 조회 API
#### [요청 파라미터]
  - x : 좌표 x값
  - y : 좌표 y값
  - radius : 조회 반경 (단위 : meter)
  - contentType : 조회 카테고리 (ex : 12 - 축제)

#### [응답 속성]
  - items : 관광지 정보 목록
    - title : 이름
    - thumbnail : 썸네일 이미지 주소 (없는 장소도 존재)
    - address : 주소
    - distance : 요청 파라미터로 전달된 좌표로부터의 거리
    - contentId: 관광지 식별자
    - contentType : 관광지 분류
  - contentId와 contentType은 상세 정보 조회에 사용됨

---
관광지 상세 정보 조회 API 구현해서 같이 올리려고 했는데 아직 기획이 안나와서 추후에 따로 구현하겠습니당