### PR TITLE
JPA Auditing 미동작 오류 해결

### DIFF
--- a/src/main/java/com/example/temp/common/config/JpaConfig.java
+++ b/src/main/java/com/example/temp/common/config/JpaConfig.java
@@ -1,7 +1,9 @@
 package com.example.temp.common.config;
 
+import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@Configuration
 @EnableJpaAuditing
 public class JpaConfig {
 


### PR DESCRIPTION
### 관련 이슈
- #20 

### 문제 내용
- JPA Auditing이 동작하지 않아 BaseTimeEntity의 속성에 해당하는 createAt과 updatedAt에 null이 들어감

### 문제 해결
- 누락된 @Configuration 어노테이션을 클래스에 추가하여 JPA Auditing을 활성화