### PR TITLE
CORS 오류 해결

### DIFF
--- a/src/main/java/com/example/temp/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/temp/common/config/SecurityConfig.java
@@ -36,6 +36,7 @@ public class SecurityConfig {
                         headerConfig.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable
                         )
                 )
+                .cors(corsConfigurer -> corsConfigurer.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests((authorizeRequests) ->
                         authorizeRequests
                                 .requestMatchers("/user/**").authenticated()
@@ -54,7 +55,6 @@ public class SecurityConfig {
         return http.build();
     }
 
-    @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration corsConfiguration = new CorsConfiguration();
         corsConfiguration.addAllowedOriginPattern("*");


### PR DESCRIPTION
### 관련 이슈
- #21 

### 문제 내용
- HttpSecurity에 CorsConfiguration 등록 코드가 누락되어 CORS 오류가 발생

### 문제 해결
- HttpSecurity에 CorsConfiguration 등록 코드를 추가