### PR TITLE
[팬풀 로그] 최신순 조회 API 구현

### DIFF
--- a/src/main/java/com/example/temp/baseball/domain/StadiumRepository.java
+++ b/src/main/java/com/example/temp/baseball/domain/StadiumRepository.java
@@ -16,4 +16,6 @@ public interface StadiumRepository extends Repository<Stadium, Long> {
     default Stadium findByOrElseThrow(Long id) {
         return findById(id).orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "Invalid Stadium Id"));
     }
+
+    boolean existsById(Long id);
 }

--- a/src/main/java/com/example/temp/tour/controller/TourController.java
+++ b/src/main/java/com/example/temp/tour/controller/TourController.java
@@ -8,6 +8,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/tour")
@@ -17,7 +19,9 @@ public class TourController {
     private final UpdateTourLogService updateTourLogService;
     private final DeleteTourLogService deleteTourLogService;
     private final RegisterTourLogService registerTourLogService;
+    private final FindRecentTourLogListService findRecentTourLogListService;
     private final FindTourInformationByLocationService findTourInformationByLocationService;
+    private final FindRecentTourLogListByStadiumService findRecentTourLogListByStadiumService;
 
     @GetMapping("/info")
     public ResponseEntity<FindTourInformationResponse> findTourInformation(
@@ -67,4 +71,19 @@ public class TourController {
         return ResponseEntity.ok().build();
     }
 
+    @GetMapping("/list")
+    public ResponseEntity<FindRecentTourLogListResponse> findRecentTourLogList(
+            @RequestParam(name = "stadiumId", required = false) Long stadiumId,
+            @RequestParam(name = "lastId", defaultValue = "" + Long.MAX_VALUE) Long lastTourLogId,
+            @RequestParam(name = "pageSize", defaultValue = "6") Integer pageSize
+    ) {
+        List<TourLogPreview> result;
+        if (stadiumId == null) {
+            result = findRecentTourLogListService.doService(lastTourLogId, pageSize);
+        } else {
+            result = findRecentTourLogListByStadiumService.doService(stadiumId, lastTourLogId, pageSize);
+        }
+        FindRecentTourLogListResponse response = new FindRecentTourLogListResponse(result);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/example/temp/tour/domain/TourLogRepository.java
+++ b/src/main/java/com/example/temp/tour/domain/TourLogRepository.java
@@ -1,11 +1,13 @@
 package com.example.temp.tour.domain;
 
 import com.example.temp.common.exception.CustomException;
+import com.example.temp.tour.dto.TourLogPreviewNativeDto;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.http.HttpStatus;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TourLogRepository extends Repository<TourLog, Long> {
@@ -37,5 +39,23 @@ public interface TourLogRepository extends Repository<TourLog, Long> {
             "JOIN FETCH ts.memo tsm " +
             "WHERE t.id = :id")
     Optional<TourLog> findByIdWithAllAssociationsForRead(@Param("id") Long id);
+
+    @Query(nativeQuery = true, value = "SELECT t.id as id, t.image_url as image, t.title as title, u.nickname as userNickname, u.profile_image_url as userProfileImage, s.shorten_name as stadiumName " +
+            "FROM tour_log t " +
+            "JOIN user u ON t.user_id = u.id " +
+            "JOIN stadium s ON t.stadium_id = s.id " +
+            "WHERE t.id < :lastId " +
+            "ORDER BY t.id DESC " +
+            "LIMIT :pageSize")
+    List<TourLogPreviewNativeDto> findRecentTourLogList(@Param("lastId") long lastTourLogId, @Param("pageSize") int pageSize);
+
+    @Query(nativeQuery = true, value = "SELECT t.id as id, t.image_url as image, t.title as title, u.nickname as userNickname, u.profile_image_url as userProfileImage, s.shorten_name as stadiumName " +
+            "FROM tour_log t " +
+            "JOIN user u ON t.user_id = u.id " +
+            "JOIN stadium s ON t.stadium_id = s.id " +
+            "WHERE t.id < :lastId AND t.stadium_id = :stadiumId " +
+            "ORDER BY t.id DESC " +
+            "LIMIT :pageSize")
+    List<TourLogPreviewNativeDto> findRecentTourLogListByStadium(@Param("stadiumId") long stadiumId, @Param("lastId") long lastTourLogId, @Param("pageSize") int pageSize);
 
 }

--- a/src/main/java/com/example/temp/tour/dto/FindRecentTourLogListResponse.java
+++ b/src/main/java/com/example/temp/tour/dto/FindRecentTourLogListResponse.java
@@ -1,0 +1,6 @@
+package com.example.temp.tour.dto;
+
+import java.util.List;
+
+public record FindRecentTourLogListResponse(List<TourLogPreview> items) {
+}

--- a/src/main/java/com/example/temp/tour/dto/TourLogPreview.java
+++ b/src/main/java/com/example/temp/tour/dto/TourLogPreview.java
@@ -1,0 +1,19 @@
+package com.example.temp.tour.dto;
+
+public record TourLogPreview(
+        String id,
+        String image,
+        String title,
+        String stadiumName,
+        UserProfileView profile
+) {
+
+    public static TourLogPreview build(TourLogPreviewNativeDto vo) {
+        return new TourLogPreview(
+                vo.getId(),
+                vo.getImage(),
+                vo.getTitle(),
+                vo.getStadiumName(),
+                new UserProfileView(vo.getUserNickname(), vo.getUserProfileImage()));
+    }
+}

--- a/src/main/java/com/example/temp/tour/dto/TourLogPreviewNativeDto.java
+++ b/src/main/java/com/example/temp/tour/dto/TourLogPreviewNativeDto.java
@@ -1,0 +1,16 @@
+package com.example.temp.tour.dto;
+
+public interface TourLogPreviewNativeDto {
+
+    String getId();
+
+    String getImage();
+
+    String getTitle();
+
+    String getUserNickname();
+
+    String getUserProfileImage();
+
+    String getStadiumName();
+}

--- a/src/main/java/com/example/temp/tour/dto/UserProfileView.java
+++ b/src/main/java/com/example/temp/tour/dto/UserProfileView.java
@@ -1,0 +1,7 @@
+package com.example.temp.tour.dto;
+
+public record UserProfileView(
+        String nickname,
+        String image
+) {
+}

--- a/src/main/java/com/example/temp/tour/service/FindRecentTourLogListByStadiumService.java
+++ b/src/main/java/com/example/temp/tour/service/FindRecentTourLogListByStadiumService.java
@@ -1,0 +1,10 @@
+package com.example.temp.tour.service;
+
+import com.example.temp.tour.dto.TourLogPreview;
+
+import java.util.List;
+
+public interface FindRecentTourLogListByStadiumService {
+
+    List<TourLogPreview> doService(long stadiumId, long lastTourLogId, int pageSize);
+}

--- a/src/main/java/com/example/temp/tour/service/FindRecentTourLogListService.java
+++ b/src/main/java/com/example/temp/tour/service/FindRecentTourLogListService.java
@@ -1,0 +1,10 @@
+package com.example.temp.tour.service;
+
+import com.example.temp.tour.dto.TourLogPreview;
+
+import java.util.List;
+
+public interface FindRecentTourLogListService {
+
+    List<TourLogPreview> doService(long lastTourLogId, int pageSize);
+}

--- a/src/main/java/com/example/temp/tour/service/impl/FindRecentTourLogListByStadiumServiceImpl.java
+++ b/src/main/java/com/example/temp/tour/service/impl/FindRecentTourLogListByStadiumServiceImpl.java
@@ -1,0 +1,33 @@
+package com.example.temp.tour.service.impl;
+
+import com.example.temp.baseball.domain.StadiumRepository;
+import com.example.temp.common.exception.CustomException;
+import com.example.temp.tour.domain.TourLogRepository;
+import com.example.temp.tour.dto.TourLogPreview;
+import com.example.temp.tour.service.FindRecentTourLogListByStadiumService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FindRecentTourLogListByStadiumServiceImpl implements FindRecentTourLogListByStadiumService {
+
+    private final StadiumRepository stadiumRepository;
+    private final TourLogRepository tourLogRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<TourLogPreview> doService(long stadiumId, long lastTourLogId, int pageSize) {
+        if (!stadiumRepository.existsById(stadiumId)) {
+            throw new CustomException(HttpStatus.NOT_FOUND, "Invalid Stadium Id");
+        }
+        return tourLogRepository.findRecentTourLogListByStadium(stadiumId, lastTourLogId, pageSize)
+                .stream()
+                .map(TourLogPreview::build)
+                .toList();
+    }
+}

--- a/src/main/java/com/example/temp/tour/service/impl/FindRecentTourLogListServiceImpl.java
+++ b/src/main/java/com/example/temp/tour/service/impl/FindRecentTourLogListServiceImpl.java
@@ -1,0 +1,26 @@
+package com.example.temp.tour.service.impl;
+
+import com.example.temp.tour.domain.TourLogRepository;
+import com.example.temp.tour.dto.TourLogPreview;
+import com.example.temp.tour.service.FindRecentTourLogListService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FindRecentTourLogListServiceImpl implements FindRecentTourLogListService {
+
+    private final TourLogRepository tourLogRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<TourLogPreview> doService(long lastTourLogId, int pageSize) {
+        return tourLogRepository.findRecentTourLogList(lastTourLogId, pageSize)
+                .stream()
+                .map(TourLogPreview::build)
+                .toList();
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- #29 

## 작업 내용
- **방문 장소의 개수 및 이름을 함께 조회하는 것은 구현이 복잡해져서 응답에서 제외했습니다**
- 투어 로그 최신순 조회 API 구현
  - stadiumId 미지정 시  전체 최신순 조회
  - stadiumId 지정 시 특정 구장의 투어 로그 최신순 조회
  - No-Offset Pagination 방식으로 구현

## 요청 & 응답 예시
<img width="1024" alt="image" src="https://github.com/user-attachments/assets/638aa261-3800-4e65-a88c-2b1fc24df0c8">
