### PR TITLE
[팬풀 로그] 북마크 기능 구현

### DIFF
--- a/src/main/java/com/example/temp/tour/controller/TourController.java
+++ b/src/main/java/com/example/temp/tour/controller/TourController.java
@@ -23,6 +23,7 @@ public class TourController {
     private final DeleteTourLogBookmarkService deleteTourLogBookmarkService;
     private final RegisterTourLogBookmarkService registerTourLogBookmarkService;
     private final FindTourInformationByLocationService findTourInformationByLocationService;
+    private final FindUserBookmarkedTourLogListService findUserBookmarkedTourLogListService;
     private final FindRecentTourLogListByStadiumService findRecentTourLogListByStadiumService;
 
     @GetMapping("/info")
@@ -105,5 +106,17 @@ public class TourController {
     ) {
         deleteTourLogBookmarkService.doService(customUserDetails.getId(), bookmarkId);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/bookmark")
+    public ResponseEntity<FindUserBookmarkedTourLogListResponse> findUserBookmarkedTourLogList(
+            @RequestParam(name = "lastId", defaultValue = "" + Long.MAX_VALUE) Long lastBookmarkId,
+            @RequestParam(name = "pageSize", defaultValue = "10") Integer pageSize,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        List<BookmarkedTourLogPreview> result = findUserBookmarkedTourLogListService.doService(
+                userDetails.getId(), lastBookmarkId, pageSize);
+        FindUserBookmarkedTourLogListResponse response = new FindUserBookmarkedTourLogListResponse(result);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/temp/tour/controller/TourController.java
+++ b/src/main/java/com/example/temp/tour/controller/TourController.java
@@ -20,6 +20,7 @@ public class TourController {
     private final DeleteTourLogService deleteTourLogService;
     private final RegisterTourLogService registerTourLogService;
     private final FindRecentTourLogListService findRecentTourLogListService;
+    private final DeleteTourLogBookmarkService deleteTourLogBookmarkService;
     private final RegisterTourLogBookmarkService registerTourLogBookmarkService;
     private final FindTourInformationByLocationService findTourInformationByLocationService;
     private final FindRecentTourLogListByStadiumService findRecentTourLogListByStadiumService;
@@ -95,5 +96,14 @@ public class TourController {
     ) {
         Long bookmarkId = registerTourLogBookmarkService.doService(customUserDetails.getId(), request.tourLogId());
         return ResponseEntity.ok(bookmarkId);
+    }
+
+    @DeleteMapping("/bookmark")
+    public ResponseEntity<Void> deleteBookmark(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestParam("id") Long bookmarkId
+    ) {
+        deleteTourLogBookmarkService.doService(customUserDetails.getId(), bookmarkId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/temp/tour/controller/TourController.java
+++ b/src/main/java/com/example/temp/tour/controller/TourController.java
@@ -20,6 +20,7 @@ public class TourController {
     private final DeleteTourLogService deleteTourLogService;
     private final RegisterTourLogService registerTourLogService;
     private final FindRecentTourLogListService findRecentTourLogListService;
+    private final FindTourLogBookmarkIdService findTourLogBookmarkIdService;
     private final DeleteTourLogBookmarkService deleteTourLogBookmarkService;
     private final RegisterTourLogBookmarkService registerTourLogBookmarkService;
     private final FindTourInformationByLocationService findTourInformationByLocationService;
@@ -106,6 +107,15 @@ public class TourController {
     ) {
         deleteTourLogBookmarkService.doService(customUserDetails.getId(), tourLogId);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/log/{tourLogId}/bookmark")
+    public ResponseEntity<String> findBookmarkId(
+            @PathVariable("tourLogId") Long tourLogId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        Long bookmarkId = findTourLogBookmarkIdService.doService(customUserDetails.getId(), tourLogId);
+        return ResponseEntity.ok(String.valueOf(bookmarkId));
     }
 
     @GetMapping("/log/bookmark")

--- a/src/main/java/com/example/temp/tour/controller/TourController.java
+++ b/src/main/java/com/example/temp/tour/controller/TourController.java
@@ -90,7 +90,7 @@ public class TourController {
         return ResponseEntity.ok(response);
     }
 
-    @PostMapping("/bookmark")
+    @PostMapping("/log/bookmark")
     public ResponseEntity<Long> registerBookmark(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestBody RegisterTourLogBookmarkRequest request
@@ -99,7 +99,7 @@ public class TourController {
         return ResponseEntity.ok(bookmarkId);
     }
 
-    @DeleteMapping("/bookmark")
+    @DeleteMapping("/log/bookmark")
     public ResponseEntity<Void> deleteBookmark(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestParam("id") Long bookmarkId
@@ -108,7 +108,7 @@ public class TourController {
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/bookmark")
+    @GetMapping("/log/bookmark")
     public ResponseEntity<FindUserBookmarkedTourLogListResponse> findUserBookmarkedTourLogList(
             @RequestParam(name = "lastId", defaultValue = "" + Long.MAX_VALUE) Long lastBookmarkId,
             @RequestParam(name = "pageSize", defaultValue = "10") Integer pageSize,

--- a/src/main/java/com/example/temp/tour/controller/TourController.java
+++ b/src/main/java/com/example/temp/tour/controller/TourController.java
@@ -90,21 +90,21 @@ public class TourController {
         return ResponseEntity.ok(response);
     }
 
-    @PostMapping("/log/bookmark")
+    @PostMapping("/log/{tourLogId}/bookmark")
     public ResponseEntity<Long> registerBookmark(
-            @AuthenticationPrincipal CustomUserDetails customUserDetails,
-            @RequestBody RegisterTourLogBookmarkRequest request
+            @PathVariable("tourLogId") Long tourLogId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
-        Long bookmarkId = registerTourLogBookmarkService.doService(customUserDetails.getId(), request.tourLogId());
+        Long bookmarkId = registerTourLogBookmarkService.doService(customUserDetails.getId(), tourLogId);
         return ResponseEntity.ok(bookmarkId);
     }
 
-    @DeleteMapping("/log/bookmark")
+    @DeleteMapping("/log/{tourLogId}/bookmark")
     public ResponseEntity<Void> deleteBookmark(
-            @AuthenticationPrincipal CustomUserDetails customUserDetails,
-            @RequestParam("id") Long bookmarkId
+            @PathVariable("tourLogId") Long tourLogId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
-        deleteTourLogBookmarkService.doService(customUserDetails.getId(), bookmarkId);
+        deleteTourLogBookmarkService.doService(customUserDetails.getId(), tourLogId);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/example/temp/tour/controller/TourController.java
+++ b/src/main/java/com/example/temp/tour/controller/TourController.java
@@ -20,6 +20,7 @@ public class TourController {
     private final DeleteTourLogService deleteTourLogService;
     private final RegisterTourLogService registerTourLogService;
     private final FindRecentTourLogListService findRecentTourLogListService;
+    private final RegisterTourLogBookmarkService registerTourLogBookmarkService;
     private final FindTourInformationByLocationService findTourInformationByLocationService;
     private final FindRecentTourLogListByStadiumService findRecentTourLogListByStadiumService;
 
@@ -85,5 +86,14 @@ public class TourController {
         }
         FindRecentTourLogListResponse response = new FindRecentTourLogListResponse(result);
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/bookmark")
+    public ResponseEntity<Long> registerBookmark(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestBody RegisterTourLogBookmarkRequest request
+    ) {
+        Long bookmarkId = registerTourLogBookmarkService.doService(customUserDetails.getId(), request.tourLogId());
+        return ResponseEntity.ok(bookmarkId);
     }
 }

--- a/src/main/java/com/example/temp/tour/domain/TourLogBookmark.java
+++ b/src/main/java/com/example/temp/tour/domain/TourLogBookmark.java
@@ -1,0 +1,37 @@
+package com.example.temp.tour.domain;
+
+import com.example.temp.common.entity.BaseTimeEntity;
+import com.example.temp.common.util.IdUtil;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Persistable;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TourLogBookmark extends BaseTimeEntity implements Persistable<Long> {
+
+    @Id
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private Long tourLogId;
+
+    public TourLogBookmark(Long userId, Long tourLogId) {
+        this.id = IdUtil.create();
+        this.userId = userId;
+        this.tourLogId = tourLogId;
+    }
+
+    @Override
+    public boolean isNew() {
+        return this.getCreatedAt() == null;
+    }
+}

--- a/src/main/java/com/example/temp/tour/domain/TourLogBookmarkRepository.java
+++ b/src/main/java/com/example/temp/tour/domain/TourLogBookmarkRepository.java
@@ -1,0 +1,10 @@
+package com.example.temp.tour.domain;
+
+import org.springframework.data.repository.Repository;
+
+public interface TourLogBookmarkRepository extends Repository<TourLogBookmark, Long> {
+
+    void save(TourLogBookmark entity);
+
+    boolean existsByUserIdAndTourLogId(Long userId, Long tourLogId);
+}

--- a/src/main/java/com/example/temp/tour/domain/TourLogBookmarkRepository.java
+++ b/src/main/java/com/example/temp/tour/domain/TourLogBookmarkRepository.java
@@ -22,6 +22,13 @@ public interface TourLogBookmarkRepository extends Repository<TourLogBookmark, L
 
     boolean existsByUserIdAndTourLogId(Long userId, Long tourLogId);
 
+    Optional<TourLogBookmark> findByUserIdAndTourLogId(Long userId, Long tourLogId);
+
+    default TourLogBookmark findByUserIdAndTourLogIdOrElseThrow(Long userId, Long tourLogId) {
+        return findByUserIdAndTourLogId(userId, tourLogId)
+                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "No Bookmark Exists"));
+    }
+
     void delete(TourLogBookmark entity);
 
     @Query(nativeQuery = true, value = "SELECT b.id as bookmarkId, t.id as tourLogId, t.image_url as image, t.title as title, u.nickname as userNickname, u.profile_image_url as userProfileImage, s.shorten_name as stadiumName " +

--- a/src/main/java/com/example/temp/tour/domain/TourLogBookmarkRepository.java
+++ b/src/main/java/com/example/temp/tour/domain/TourLogBookmarkRepository.java
@@ -1,9 +1,13 @@
 package com.example.temp.tour.domain;
 
 import com.example.temp.common.exception.CustomException;
+import com.example.temp.tour.dto.BookmarkedTourLogPreviewNativeDto;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.http.HttpStatus;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TourLogBookmarkRepository extends Repository<TourLogBookmark, Long> {
@@ -19,4 +23,18 @@ public interface TourLogBookmarkRepository extends Repository<TourLogBookmark, L
     boolean existsByUserIdAndTourLogId(Long userId, Long tourLogId);
 
     void delete(TourLogBookmark entity);
+
+    @Query(nativeQuery = true, value = "SELECT b.id as bookmarkId, t.id as tourLogId, t.image_url as image, t.title as title, u.nickname as userNickname, u.profile_image_url as userProfileImage, s.shorten_name as stadiumName " +
+            "FROM tour_log_bookmark b " +
+            "JOIN tour_log t on t.id = b.tour_log_id " +
+            "JOIN user u ON t.user_id = u.id " +
+            "JOIN stadium s ON t.stadium_id = s.id " +
+            "WHERE b.user_id = :userId AND b.id < :lastId " +
+            "ORDER BY b.id DESC " +
+            "LIMIT :pageSize")
+    List<BookmarkedTourLogPreviewNativeDto> findUserBookmarkedTourLogPreviewList(
+            @Param("userId") Long userId,
+            @Param("lastId") Long lastBookmarkId,
+            @Param("pageSize") int pageSize
+    );
 }

--- a/src/main/java/com/example/temp/tour/domain/TourLogBookmarkRepository.java
+++ b/src/main/java/com/example/temp/tour/domain/TourLogBookmarkRepository.java
@@ -1,10 +1,22 @@
 package com.example.temp.tour.domain;
 
+import com.example.temp.common.exception.CustomException;
 import org.springframework.data.repository.Repository;
+import org.springframework.http.HttpStatus;
+
+import java.util.Optional;
 
 public interface TourLogBookmarkRepository extends Repository<TourLogBookmark, Long> {
 
     void save(TourLogBookmark entity);
 
+    Optional<TourLogBookmark> findById(Long id);
+
+    default TourLogBookmark findByIdOrElseThrow(Long id) {
+        return findById(id).orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "Invalid Bookmark Id"));
+    }
+
     boolean existsByUserIdAndTourLogId(Long userId, Long tourLogId);
+
+    void delete(TourLogBookmark entity);
 }

--- a/src/main/java/com/example/temp/tour/domain/TourLogRepository.java
+++ b/src/main/java/com/example/temp/tour/domain/TourLogRepository.java
@@ -58,4 +58,5 @@ public interface TourLogRepository extends Repository<TourLog, Long> {
             "LIMIT :pageSize")
     List<TourLogPreviewNativeDto> findRecentTourLogListByStadium(@Param("stadiumId") long stadiumId, @Param("lastId") long lastTourLogId, @Param("pageSize") int pageSize);
 
+    boolean existsById(Long id);
 }

--- a/src/main/java/com/example/temp/tour/dto/BookmarkedTourLogPreview.java
+++ b/src/main/java/com/example/temp/tour/dto/BookmarkedTourLogPreview.java
@@ -1,0 +1,17 @@
+package com.example.temp.tour.dto;
+
+public record BookmarkedTourLogPreview(
+        String id,
+        TourLogPreview tourLog
+) {
+    public static BookmarkedTourLogPreview build(BookmarkedTourLogPreviewNativeDto vo) {
+        TourLogPreview tourLogPreview = new TourLogPreview(
+                vo.getTourLogId(),
+                vo.getImage(),
+                vo.getTitle(),
+                vo.getStadiumName(),
+                new UserProfileView(vo.getUserNickname(), vo.getUserProfileImage()));
+
+        return new BookmarkedTourLogPreview(vo.getBookmarkId(), tourLogPreview);
+    }
+}

--- a/src/main/java/com/example/temp/tour/dto/BookmarkedTourLogPreviewNativeDto.java
+++ b/src/main/java/com/example/temp/tour/dto/BookmarkedTourLogPreviewNativeDto.java
@@ -1,0 +1,18 @@
+package com.example.temp.tour.dto;
+
+public interface BookmarkedTourLogPreviewNativeDto {
+
+    String getBookmarkId();
+
+    String getTourLogId();
+
+    String getImage();
+
+    String getTitle();
+
+    String getUserNickname();
+
+    String getUserProfileImage();
+
+    String getStadiumName();
+}

--- a/src/main/java/com/example/temp/tour/dto/FindUserBookmarkedTourLogListResponse.java
+++ b/src/main/java/com/example/temp/tour/dto/FindUserBookmarkedTourLogListResponse.java
@@ -1,0 +1,6 @@
+package com.example.temp.tour.dto;
+
+import java.util.List;
+
+public record FindUserBookmarkedTourLogListResponse(List<BookmarkedTourLogPreview> bookmarks) {
+}

--- a/src/main/java/com/example/temp/tour/dto/RegisterTourLogBookmarkRequest.java
+++ b/src/main/java/com/example/temp/tour/dto/RegisterTourLogBookmarkRequest.java
@@ -1,0 +1,4 @@
+package com.example.temp.tour.dto;
+
+public record RegisterTourLogBookmarkRequest(Long tourLogId) {
+}

--- a/src/main/java/com/example/temp/tour/service/DeleteTourLogBookmarkService.java
+++ b/src/main/java/com/example/temp/tour/service/DeleteTourLogBookmarkService.java
@@ -2,5 +2,5 @@ package com.example.temp.tour.service;
 
 public interface DeleteTourLogBookmarkService {
 
-    void doService(Long userId, Long bookmarkId);
+    void doService(Long userId, Long tourLogId);
 }

--- a/src/main/java/com/example/temp/tour/service/DeleteTourLogBookmarkService.java
+++ b/src/main/java/com/example/temp/tour/service/DeleteTourLogBookmarkService.java
@@ -1,0 +1,6 @@
+package com.example.temp.tour.service;
+
+public interface DeleteTourLogBookmarkService {
+
+    void doService(Long userId, Long bookmarkId);
+}

--- a/src/main/java/com/example/temp/tour/service/FindTourLogBookmarkIdService.java
+++ b/src/main/java/com/example/temp/tour/service/FindTourLogBookmarkIdService.java
@@ -1,0 +1,6 @@
+package com.example.temp.tour.service;
+
+public interface FindTourLogBookmarkIdService {
+
+    Long doService(Long userId, Long tourLogId);
+}

--- a/src/main/java/com/example/temp/tour/service/FindUserBookmarkedTourLogListService.java
+++ b/src/main/java/com/example/temp/tour/service/FindUserBookmarkedTourLogListService.java
@@ -1,0 +1,10 @@
+package com.example.temp.tour.service;
+
+import com.example.temp.tour.dto.BookmarkedTourLogPreview;
+
+import java.util.List;
+
+public interface FindUserBookmarkedTourLogListService {
+
+    List<BookmarkedTourLogPreview> doService(Long userId, Long lastBookmarkId, int pageSize);
+}

--- a/src/main/java/com/example/temp/tour/service/RegisterTourLogBookmarkService.java
+++ b/src/main/java/com/example/temp/tour/service/RegisterTourLogBookmarkService.java
@@ -1,0 +1,6 @@
+package com.example.temp.tour.service;
+
+public interface RegisterTourLogBookmarkService {
+
+    Long doService(Long userId, Long tourLogId);
+}

--- a/src/main/java/com/example/temp/tour/service/impl/DeleteTourLogBookmarkServiceImpl.java
+++ b/src/main/java/com/example/temp/tour/service/impl/DeleteTourLogBookmarkServiceImpl.java
@@ -1,0 +1,27 @@
+package com.example.temp.tour.service.impl;
+
+import com.example.temp.common.exception.CustomException;
+import com.example.temp.tour.domain.TourLogBookmark;
+import com.example.temp.tour.domain.TourLogBookmarkRepository;
+import com.example.temp.tour.service.DeleteTourLogBookmarkService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteTourLogBookmarkServiceImpl implements DeleteTourLogBookmarkService {
+
+    private final TourLogBookmarkRepository tourLogBookmarkRepository;
+
+    @Override
+    @Transactional
+    public void doService(Long userId, Long bookmarkId) {
+        TourLogBookmark bookmark = tourLogBookmarkRepository.findByIdOrElseThrow(bookmarkId);
+        if (!bookmark.getUserId().equals(userId)) {
+            throw new CustomException(HttpStatus.FORBIDDEN, "Illegal Request");
+        }
+        tourLogBookmarkRepository.delete(bookmark);
+    }
+}

--- a/src/main/java/com/example/temp/tour/service/impl/DeleteTourLogBookmarkServiceImpl.java
+++ b/src/main/java/com/example/temp/tour/service/impl/DeleteTourLogBookmarkServiceImpl.java
@@ -17,8 +17,8 @@ public class DeleteTourLogBookmarkServiceImpl implements DeleteTourLogBookmarkSe
 
     @Override
     @Transactional
-    public void doService(Long userId, Long bookmarkId) {
-        TourLogBookmark bookmark = tourLogBookmarkRepository.findByIdOrElseThrow(bookmarkId);
+    public void doService(Long userId, Long tourLogId) {
+        TourLogBookmark bookmark = tourLogBookmarkRepository.findByUserIdAndTourLogIdOrElseThrow(userId, tourLogId);
         if (!bookmark.getUserId().equals(userId)) {
             throw new CustomException(HttpStatus.FORBIDDEN, "Illegal Request");
         }

--- a/src/main/java/com/example/temp/tour/service/impl/FindTourLogBookmarkIdServiceImpl.java
+++ b/src/main/java/com/example/temp/tour/service/impl/FindTourLogBookmarkIdServiceImpl.java
@@ -1,0 +1,22 @@
+package com.example.temp.tour.service.impl;
+
+import com.example.temp.tour.domain.TourLogBookmark;
+import com.example.temp.tour.domain.TourLogBookmarkRepository;
+import com.example.temp.tour.service.FindTourLogBookmarkIdService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FindTourLogBookmarkIdServiceImpl implements FindTourLogBookmarkIdService {
+
+    private final TourLogBookmarkRepository tourLogBookmarkRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public Long doService(Long userId, Long tourLogId) {
+        TourLogBookmark tourLogBookmark = tourLogBookmarkRepository.findByUserIdAndTourLogIdOrElseThrow(userId, tourLogId);
+        return tourLogBookmark.getId();
+    }
+}

--- a/src/main/java/com/example/temp/tour/service/impl/FindUserBookmarkedTourLogListServiceImpl.java
+++ b/src/main/java/com/example/temp/tour/service/impl/FindUserBookmarkedTourLogListServiceImpl.java
@@ -1,0 +1,26 @@
+package com.example.temp.tour.service.impl;
+
+import com.example.temp.tour.domain.TourLogBookmarkRepository;
+import com.example.temp.tour.dto.BookmarkedTourLogPreview;
+import com.example.temp.tour.service.FindUserBookmarkedTourLogListService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FindUserBookmarkedTourLogListServiceImpl implements FindUserBookmarkedTourLogListService {
+
+    private final TourLogBookmarkRepository tourLogBookmarkRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<BookmarkedTourLogPreview> doService(Long userId, Long lastBookmarkId, int pageSize) {
+        return tourLogBookmarkRepository.findUserBookmarkedTourLogPreviewList(userId, lastBookmarkId, pageSize)
+                .stream()
+                .map(BookmarkedTourLogPreview::build)
+                .toList();
+    }
+}

--- a/src/main/java/com/example/temp/tour/service/impl/RegisterTourLogBookmarkServiceImpl.java
+++ b/src/main/java/com/example/temp/tour/service/impl/RegisterTourLogBookmarkServiceImpl.java
@@ -1,0 +1,33 @@
+package com.example.temp.tour.service.impl;
+
+import com.example.temp.common.exception.CustomException;
+import com.example.temp.tour.domain.TourLogBookmark;
+import com.example.temp.tour.domain.TourLogBookmarkRepository;
+import com.example.temp.tour.domain.TourLogRepository;
+import com.example.temp.tour.service.RegisterTourLogBookmarkService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RegisterTourLogBookmarkServiceImpl implements RegisterTourLogBookmarkService {
+
+    private final TourLogRepository tourLogRepository;
+    private final TourLogBookmarkRepository tourLogBookmarkRepository;
+
+    @Override
+    @Transactional
+    public Long doService(Long userId, Long tourLogId) {
+        if (!tourLogRepository.existsById(tourLogId)) {
+            throw new CustomException(HttpStatus.NOT_FOUND, "Invalid Tour Log Id");
+        }
+        if (tourLogBookmarkRepository.existsByUserIdAndTourLogId(userId, tourLogId)) {
+            throw new CustomException(HttpStatus.CONFLICT, "The Bookmark Already Exists");
+        }
+        TourLogBookmark tourLogBookmark = new TourLogBookmark(userId, tourLogId);
+        tourLogBookmarkRepository.save(tourLogBookmark);
+        return tourLogBookmark.getId();
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- #34 

## 작업 내용
<img width="312" alt="image" src="https://github.com/user-attachments/assets/26e0a88f-1a3f-4205-90e7-03eea20aaf8b">


- 팬풀 로그 북마크 기능 구현
  - 아직 북마크 조회 화면 디자인이 나오질 않아 위의 화면을 기준으로 API를 구현
- 투어 로그 식별자를 통해 북마크 생성, 삭제, 상태 조회 API 호출