### PR TITLE
[투어 로그] 조회 API 응답에 작성자 식별자 항목 추가

### DIFF
--- a/src/main/java/com/example/temp/tour/dto/TourLogUserProfileView.java
+++ b/src/main/java/com/example/temp/tour/dto/TourLogUserProfileView.java
@@ -2,10 +2,11 @@ package com.example.temp.tour.dto;
 
 import com.example.temp.user.domain.User;
 
-public record TourLogUserProfileView(String nickname, String image) {
+public record TourLogUserProfileView(String userId, String nickname, String image) {
 
     public static TourLogUserProfileView of(User user) {
         return new TourLogUserProfileView(
+                user.getId().toString(),
                 user.getNickname(),
                 user.getProfileImageUrl()
         );


### PR DESCRIPTION
### 관련 이슈
- close #52

### 작업 내용
- 프론트측 '편집' 버튼 표시 여부를 결정하기 위해 투어 로그 작성자의 식별자값을 응답에 추가
