### PR TITLE
chore: AWS SDK 의존성 변경 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,8 +56,9 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
-    // AWS SDK for Java
-    implementation 'com.amazonaws:aws-java-sdk:1.12.771'
+    // AWS Java SDK For Amazon S3
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.772'
+
 }
 
 tasks.named('test') {


### PR DESCRIPTION
## 변경사항
- AWS SDK 의존성 변경 : AWS SDK For Java -> AWS Java SDK For Amazon S3
  - S3만 사용하고 있기 때문에 SDK For Amazon S3로 전환