### PR TITLE
[팬풀 로그] 팬풀 로그 전용 경기장 엔티티 및 경기장 목록 조회 API 추가

### DIFF
--- a/src/main/java/com/example/temp/tour/controller/TourController.java
+++ b/src/main/java/com/example/temp/tour/controller/TourController.java
@@ -1,6 +1,7 @@
 package com.example.temp.tour.controller;
 
 import com.example.temp.common.entity.CustomUserDetails;
+import com.example.temp.tour.controller.dto.TourLogStadiumView;
 import com.example.temp.tour.dto.*;
 import com.example.temp.tour.service.*;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,7 @@ public class TourController {
     private final FindTourDetailsService findTourDetailsService;
     private final FindRecentTourLogListService findRecentTourLogListService;
     private final FindTourLogBookmarkIdService findTourLogBookmarkIdService;
+    private final FindAllTourLogStadiumService findAllTourLogStadiumService;
     private final DeleteTourLogBookmarkService deleteTourLogBookmarkService;
     private final RegisterTourLogBookmarkService registerTourLogBookmarkService;
     private final FindTourInformationByLocationService findTourInformationByLocationService;
@@ -142,4 +144,12 @@ public class TourController {
         FindUserBookmarkedTourLogListResponse response = new FindUserBookmarkedTourLogListResponse(result);
         return ResponseEntity.ok(response);
     }
+
+    @GetMapping("/stadium/list")
+    public ResponseEntity<FindAllTourLogStadiumResponse> findAllStadium() {
+        List<TourLogStadiumView> stadiumViews = findAllTourLogStadiumService.doService();
+        FindAllTourLogStadiumResponse response = new FindAllTourLogStadiumResponse(stadiumViews);
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/java/com/example/temp/tour/controller/dto/TourLogStadiumView.java
+++ b/src/main/java/com/example/temp/tour/controller/dto/TourLogStadiumView.java
@@ -1,0 +1,30 @@
+package com.example.temp.tour.controller.dto;
+
+import com.example.temp.tour.domain.TourLogStadium;
+
+public record TourLogStadiumView(
+        String id,
+        String address,
+        String contentType,
+        String contentId,
+        String name,
+        String shortenName,
+        String thumbnail,
+        String x,
+        String y
+) {
+
+    public static TourLogStadiumView of(TourLogStadium tourLogStadium) {
+        return new TourLogStadiumView(
+                tourLogStadium.getId().toString(),
+                tourLogStadium.getAddress(),
+                tourLogStadium.getContentTypeId(),
+                tourLogStadium.getContentId(),
+                tourLogStadium.getName(),
+                tourLogStadium.getShortenName(),
+                tourLogStadium.getImage(),
+                tourLogStadium.getX(),
+                tourLogStadium.getY()
+        );
+    }
+}

--- a/src/main/java/com/example/temp/tour/domain/TourLog.java
+++ b/src/main/java/com/example/temp/tour/domain/TourLog.java
@@ -1,6 +1,5 @@
 package com.example.temp.tour.domain;
 
-import com.example.temp.baseball.domain.Stadium;
 import com.example.temp.common.entity.BaseTimeEntity;
 import com.example.temp.common.util.IdUtil;
 import com.example.temp.user.domain.User;
@@ -26,7 +25,7 @@ public class TourLog extends BaseTimeEntity {
 
     @JoinColumn(name = "stadium_id")
     @ManyToOne(fetch = FetchType.LAZY)
-    private Stadium stadium;
+    private TourLogStadium stadium;
 
     @Embedded
     private TourLogTitle title;
@@ -37,7 +36,7 @@ public class TourLog extends BaseTimeEntity {
     @OneToMany(mappedBy = "tourLog", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<TourSchedule> schedules = new ArrayList<>();
 
-    public TourLog(User user, Stadium stadium, String title, String image) {
+    public TourLog(User user, TourLogStadium stadium, String title, String image) {
         this.id = IdUtil.create();
         this.user = user;
         this.stadium = stadium;

--- a/src/main/java/com/example/temp/tour/domain/TourLogBookmarkRepository.java
+++ b/src/main/java/com/example/temp/tour/domain/TourLogBookmarkRepository.java
@@ -35,7 +35,7 @@ public interface TourLogBookmarkRepository extends Repository<TourLogBookmark, L
             "FROM tour_log_bookmark b " +
             "JOIN tour_log t on t.id = b.tour_log_id " +
             "JOIN user u ON t.user_id = u.id " +
-            "JOIN stadium s ON t.stadium_id = s.id " +
+            "JOIN tour_log_stadium s ON t.stadium_id = s.id " +
             "WHERE b.user_id = :userId AND b.id < :lastId " +
             "ORDER BY b.id DESC " +
             "LIMIT :pageSize")

--- a/src/main/java/com/example/temp/tour/domain/TourLogRepository.java
+++ b/src/main/java/com/example/temp/tour/domain/TourLogRepository.java
@@ -43,7 +43,7 @@ public interface TourLogRepository extends Repository<TourLog, Long> {
     @Query(nativeQuery = true, value = "SELECT t.id as id, t.image_url as image, t.title as title, u.nickname as userNickname, u.profile_image_url as userProfileImage, s.shorten_name as stadiumName " +
             "FROM tour_log t " +
             "JOIN user u ON t.user_id = u.id " +
-            "JOIN stadium s ON t.stadium_id = s.id " +
+            "JOIN tour_log_stadium s ON t.stadium_id = s.id " +
             "WHERE t.id < :lastId " +
             "ORDER BY t.id DESC " +
             "LIMIT :pageSize")
@@ -52,7 +52,7 @@ public interface TourLogRepository extends Repository<TourLog, Long> {
     @Query(nativeQuery = true, value = "SELECT t.id as id, t.image_url as image, t.title as title, u.nickname as userNickname, u.profile_image_url as userProfileImage, s.shorten_name as stadiumName " +
             "FROM tour_log t " +
             "JOIN user u ON t.user_id = u.id " +
-            "JOIN stadium s ON t.stadium_id = s.id " +
+            "JOIN tour_log_stadium s ON t.stadium_id = s.id " +
             "WHERE t.id < :lastId AND t.stadium_id = :stadiumId " +
             "ORDER BY t.id DESC " +
             "LIMIT :pageSize")

--- a/src/main/java/com/example/temp/tour/domain/TourLogStadium.java
+++ b/src/main/java/com/example/temp/tour/domain/TourLogStadium.java
@@ -1,0 +1,32 @@
+package com.example.temp.tour.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TourLogStadium {
+
+    @Id
+    private Long id;
+
+    private String address;
+
+    private String contentId;
+
+    private String contentTypeId;
+
+    private String name;
+
+    private String shortenName;
+
+    private String image;
+
+    private String x;
+
+    private String y;
+}

--- a/src/main/java/com/example/temp/tour/domain/TourLogStadiumRepository.java
+++ b/src/main/java/com/example/temp/tour/domain/TourLogStadiumRepository.java
@@ -1,0 +1,22 @@
+package com.example.temp.tour.domain;
+
+import com.example.temp.common.exception.CustomException;
+import org.springframework.data.repository.Repository;
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TourLogStadiumRepository extends Repository<TourLogStadium, Long> {
+
+    List<TourLogStadium> findAll();
+
+    Optional<TourLogStadium> findById(Long id);
+
+    default TourLogStadium findByIdOrElseThrow(Long id) {
+        return findById(id)
+                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "Invalid Stadium Id"));
+    }
+
+    boolean existsById(Long id);
+}

--- a/src/main/java/com/example/temp/tour/dto/FindAllTourLogStadiumResponse.java
+++ b/src/main/java/com/example/temp/tour/dto/FindAllTourLogStadiumResponse.java
@@ -1,0 +1,8 @@
+package com.example.temp.tour.dto;
+
+import com.example.temp.tour.controller.dto.TourLogStadiumView;
+
+import java.util.List;
+
+public record FindAllTourLogStadiumResponse(List<TourLogStadiumView> stadiums) {
+}

--- a/src/main/java/com/example/temp/tour/service/FindAllTourLogStadiumService.java
+++ b/src/main/java/com/example/temp/tour/service/FindAllTourLogStadiumService.java
@@ -1,0 +1,10 @@
+package com.example.temp.tour.service;
+
+import com.example.temp.tour.controller.dto.TourLogStadiumView;
+
+import java.util.List;
+
+public interface FindAllTourLogStadiumService {
+
+    List<TourLogStadiumView> doService();
+}

--- a/src/main/java/com/example/temp/tour/service/impl/FindAllTourLogStadiumServiceImpl.java
+++ b/src/main/java/com/example/temp/tour/service/impl/FindAllTourLogStadiumServiceImpl.java
@@ -1,0 +1,24 @@
+package com.example.temp.tour.service.impl;
+
+import com.example.temp.tour.controller.dto.TourLogStadiumView;
+import com.example.temp.tour.domain.TourLogStadiumRepository;
+import com.example.temp.tour.service.FindAllTourLogStadiumService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FindAllTourLogStadiumServiceImpl implements FindAllTourLogStadiumService {
+
+    private final TourLogStadiumRepository tourLogStadiumRepository;
+
+    @Override
+    public List<TourLogStadiumView> doService() {
+        return tourLogStadiumRepository.findAll()
+                .stream()
+                .map(TourLogStadiumView::of)
+                .toList();
+    }
+}

--- a/src/main/java/com/example/temp/tour/service/impl/FindRecentTourLogListByStadiumServiceImpl.java
+++ b/src/main/java/com/example/temp/tour/service/impl/FindRecentTourLogListByStadiumServiceImpl.java
@@ -1,8 +1,8 @@
 package com.example.temp.tour.service.impl;
 
-import com.example.temp.baseball.domain.StadiumRepository;
 import com.example.temp.common.exception.CustomException;
 import com.example.temp.tour.domain.TourLogRepository;
+import com.example.temp.tour.domain.TourLogStadiumRepository;
 import com.example.temp.tour.dto.TourLogPreview;
 import com.example.temp.tour.service.FindRecentTourLogListByStadiumService;
 import lombok.RequiredArgsConstructor;
@@ -16,13 +16,13 @@ import java.util.List;
 @RequiredArgsConstructor
 public class FindRecentTourLogListByStadiumServiceImpl implements FindRecentTourLogListByStadiumService {
 
-    private final StadiumRepository stadiumRepository;
     private final TourLogRepository tourLogRepository;
+    private final TourLogStadiumRepository tourLogStadiumRepository;
 
     @Override
     @Transactional(readOnly = true)
     public List<TourLogPreview> doService(long stadiumId, long lastTourLogId, int pageSize) {
-        if (!stadiumRepository.existsById(stadiumId)) {
+        if (!tourLogStadiumRepository.existsById(stadiumId)) {
             throw new CustomException(HttpStatus.NOT_FOUND, "Invalid Stadium Id");
         }
         return tourLogRepository.findRecentTourLogListByStadium(stadiumId, lastTourLogId, pageSize)

--- a/src/main/java/com/example/temp/tour/service/impl/RegisterTourLogServiceImpl.java
+++ b/src/main/java/com/example/temp/tour/service/impl/RegisterTourLogServiceImpl.java
@@ -1,7 +1,5 @@
 package com.example.temp.tour.service.impl;
 
-import com.example.temp.baseball.domain.Stadium;
-import com.example.temp.baseball.domain.StadiumRepository;
 import com.example.temp.tour.domain.*;
 import com.example.temp.tour.dto.RegisterTourLogRequest;
 import com.example.temp.tour.dto.TourPlaceView;
@@ -21,15 +19,15 @@ import java.util.List;
 public class RegisterTourLogServiceImpl implements RegisterTourLogService {
 
     private final UserRepository userRepository;
-    private final StadiumRepository stadiumRepository;
     private final TourLogRepository tourLogRepository;
     private final TourPlaceRepository tourPlaceRepository;
+    private final TourLogStadiumRepository tourLogStadiumRepository;
 
     @Override
     @Transactional
     public Long doService(Long userId, RegisterTourLogRequest request) {
         User user = userRepository.findByIdOrElseThrow(userId);
-        Stadium stadium = stadiumRepository.findByOrElseThrow(Long.parseLong(request.stadiumId()));
+        TourLogStadium stadium = tourLogStadiumRepository.findByIdOrElseThrow(Long.valueOf(request.stadiumId()));
 
         TourLog tourLog = new TourLog(user, stadium, request.title(), request.image());
 


### PR DESCRIPTION
### 작업 내용
- 팬풀 로그 전용 경기장 엔티티 추가
  - 기존 : 경기(baseball) 도메인에 존재하던 경기장(Stadium) 엔티티를 투어(tour) 도메인에서 공유하며 사용
  - 변경 : 투어 도메인에서 사용되는 전용의 경기장 엔티티 TourLogStadium 추가 및 기존 Stadium 엔티티 대체
- 팬풀 로그 경기장 목록 조회 API 추가