### PR TITLE
[팬풀 로그] 등록된 일정 혹은 메모가 없는 경우 팬풀 로그 조회에 실패하는 오류 해결

### DIFF
--- a/src/main/java/com/example/temp/tour/domain/TourLogRepository.java
+++ b/src/main/java/com/example/temp/tour/domain/TourLogRepository.java
@@ -25,18 +25,18 @@ public interface TourLogRepository extends Repository<TourLog, Long> {
     // 페치 조인은 최대 1개의 OneToMany 연관 관계만 가능해서 TourScheduleMemoImage까지는 페치 조인이 불가능
     // TourScheduleMemo - TourScheduleMemoImage 간에 N+1 문제를 해결하고자 Batch Size 설정
     @Query("SELECT t FROM TourLog t " +
-            "JOIN FETCH t.schedules ts " +
-            "JOIN FETCH ts.tourPlace tp " +
-            "JOIN FETCH ts.memo tsm " +
+            "LEFT JOIN FETCH t.schedules ts " +
+            "LEFT JOIN FETCH ts.tourPlace tp " +
+            "LEFT JOIN FETCH ts.memo tsm " +
             "WHERE t.id = :id")
     Optional<TourLog> findByIdWithAllAssociationsForUpdate(@Param("id") Long id);
 
     @Query("SELECT t FROM TourLog t " +
             "JOIN FETCH t.user u " +
             "JOIN FETCH t.stadium s " +
-            "JOIN FETCH t.schedules ts " +
-            "JOIN FETCH ts.tourPlace tp " +
-            "JOIN FETCH ts.memo tsm " +
+            "LEFT JOIN FETCH t.schedules ts " +
+            "LEFT JOIN FETCH ts.tourPlace tp " +
+            "LEFT JOIN FETCH ts.memo tsm " +
             "WHERE t.id = :id")
     Optional<TourLog> findByIdWithAllAssociationsForRead(@Param("id") Long id);
 

--- a/src/main/java/com/example/temp/tour/dto/TourScheduleView.java
+++ b/src/main/java/com/example/temp/tour/dto/TourScheduleView.java
@@ -15,7 +15,7 @@ public record TourScheduleView(
                 TourPlaceView.of(tourSchedule.getTourPlace()),
                 tourSchedule.getDay(),
                 tourSchedule.getSequence(),
-                TourScheduleMemoView.of(tourSchedule.getMemo())
+                tourSchedule.getMemo() != null ? TourScheduleMemoView.of(tourSchedule.getMemo()) : null
         );
     }
 }


### PR DESCRIPTION
### 작업 내용
- close #49 
- 문제 원인: 내부 조인 사용으로 인해 등록된 일정 혹은 메모가 없는 경우 조회에 실패
- 문제 해결: 내부 조인을 외부 조인으로 변경