### PR TITLE
[팬풀 로그] 식별자 응답 타입 변경

### DIFF
--- a/src/main/java/com/example/temp/common/dto/IdResponse.java
+++ b/src/main/java/com/example/temp/common/dto/IdResponse.java
@@ -1,0 +1,8 @@
+package com.example.temp.common.dto;
+
+public record IdResponse(String id) {
+
+    public static IdResponse build(Long id) {
+        return new IdResponse(id.toString());
+    }
+}

--- a/src/main/java/com/example/temp/tour/controller/TourController.java
+++ b/src/main/java/com/example/temp/tour/controller/TourController.java
@@ -1,5 +1,6 @@
 package com.example.temp.tour.controller;
 
+import com.example.temp.common.dto.IdResponse;
 import com.example.temp.common.entity.CustomUserDetails;
 import com.example.temp.tour.controller.dto.TourLogStadiumView;
 import com.example.temp.tour.dto.*;
@@ -58,12 +59,12 @@ public class TourController {
     }
 
     @PostMapping("/log")
-    public ResponseEntity<String> registerTourLog(
+    public ResponseEntity<IdResponse> registerTourLog(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody RegisterTourLogRequest request
     ) {
         Long tourLogId = registerTourLogService.doService(userDetails.getId(), request);
-        return ResponseEntity.ok(String.valueOf(tourLogId));
+        return ResponseEntity.ok(IdResponse.build(tourLogId));
     }
 
     @GetMapping("/log")
@@ -107,12 +108,12 @@ public class TourController {
     }
 
     @PostMapping("/log/{tourLogId}/bookmark")
-    public ResponseEntity<String> registerBookmark(
+    public ResponseEntity<IdResponse> registerBookmark(
             @PathVariable("tourLogId") Long tourLogId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
         Long bookmarkId = registerTourLogBookmarkService.doService(customUserDetails.getId(), tourLogId);
-        return ResponseEntity.ok(String.valueOf(bookmarkId));
+        return ResponseEntity.ok(IdResponse.build(bookmarkId));
     }
 
     @DeleteMapping("/log/{tourLogId}/bookmark")
@@ -125,12 +126,12 @@ public class TourController {
     }
 
     @GetMapping("/log/{tourLogId}/bookmark")
-    public ResponseEntity<String> findBookmarkId(
+    public ResponseEntity<IdResponse> findBookmarkId(
             @PathVariable("tourLogId") Long tourLogId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
         Long bookmarkId = findTourLogBookmarkIdService.doService(customUserDetails.getId(), tourLogId);
-        return ResponseEntity.ok(String.valueOf(bookmarkId));
+        return ResponseEntity.ok(IdResponse.build(bookmarkId));
     }
 
     @GetMapping("/log/bookmark")


### PR DESCRIPTION
### 작업 내용
- Response Body에 64비트 식별자를 그대로 응답하면 프론트측에서 정수 표현 범위 문제로 인해 값을 제대로 받지 못함
- 이를 해결하기 위해 JSON으로 담아서 응답