### PR TITLE
야구 경기 수정사항 추가 구현

### DIFF
--- a/src/main/java/com/example/temp/baseball/controller/BaseballGameController.java
+++ b/src/main/java/com/example/temp/baseball/controller/BaseballGameController.java
@@ -4,9 +4,11 @@ import com.example.temp.baseball.dto.FindGamesByTeamCommand;
 import com.example.temp.baseball.dto.FindGamesByTeamResponse;
 import com.example.temp.baseball.dto.GameScheduleResponse;
 import com.example.temp.baseball.dto.GameSchedulesRequest;
+import com.example.temp.baseball.service.CountFanpoolRelatedFanpoolService;
 import com.example.temp.baseball.service.CreateGameSchedulesService;
 import com.example.temp.baseball.service.FindAllSchedulesDuringThisWeekService;
 import com.example.temp.baseball.service.FindGamesByTeamService;
+import com.example.temp.common.dto.IdResponse;
 import com.example.temp.common.entity.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -24,6 +26,7 @@ public class BaseballGameController {
     private final FindGamesByTeamService findGamesByTeamService;
     private final FindAllSchedulesDuringThisWeekService findAllSchedulesDuringThisWeekService;
     private final CreateGameSchedulesService createGameSchedulesService;
+    private final CountFanpoolRelatedFanpoolService countFanpoolRelatedFanpoolService;
 
     @GetMapping
     public ResponseEntity<FindGamesByTeamResponse> findByTeam(
@@ -35,6 +38,14 @@ public class BaseballGameController {
         FindGamesByTeamCommand command = new FindGamesByTeamCommand(Long.parseLong(teamId), startDate, endDate);
         FindGamesByTeamResponse result = findGamesByTeamService.doService(command);
         return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/{gameId}")
+    public ResponseEntity<IdResponse> countFanpool(
+            @PathVariable(value = "gameId") String gameId
+    ) {
+        long result = countFanpoolRelatedFanpoolService.doService(Long.parseLong(gameId));
+        return ResponseEntity.ok(IdResponse.build(result));
     }
 
     @GetMapping("/schedules")

--- a/src/main/java/com/example/temp/baseball/domain/GameRepository.java
+++ b/src/main/java/com/example/temp/baseball/domain/GameRepository.java
@@ -29,16 +29,13 @@ public interface GameRepository extends Repository<Game, Long> {
         return findById(gameId).orElseThrow(() -> new CustomException(HttpStatus.BAD_REQUEST, "Game not found"));
     }
 
-    @Query(value = "SELECT g FROM Game g " +
-            "WHERE  (g.awayTeam = :team OR g.homeTeam = :team) " +
-            "AND (g.state = 'BEFORE_START' OR g.state = 'IN_PROGRESS') " +
+    @Query("SELECT g FROM Game g " +
+            "WHERE (:team IS NULL OR g.awayTeam = :team OR g.homeTeam = :team) " +
+            "   AND (:startDate IS NULL OR DATE(g.startDate) >= :startDate) " +
+            "   AND (:endDate IS NULL OR DATE(g.startDate) <= :endDate) " +
+            "   AND (g.state = 'BEFORE_START' OR g.state = 'IN_PROGRESS') " +
             "ORDER BY g.startDate")
-    List<Game> findByTeamOrderByStartDate(Team team);
-
-    @Query(value = "SELECT g FROM Game g " +
-            "WHERE  (g.awayTeam = :team OR g.homeTeam = :team) " +
-            "AND DATE(g.startDate) BETWEEN :startDate AND :endDate " +
-            "AND (g.state = 'BEFORE_START' OR g.state = 'IN_PROGRESS') " +
-            "ORDER BY g.startDate")
-    List<Game> findByTeamAndDateOrderByStartDate(Team team, LocalDateTime startDate, LocalDateTime endDate);
+    List<Game> findByTeamOrDateOrderByStartDate(@Param("team") Team team,
+                                                @Param("startDate") LocalDateTime startDate,
+                                                @Param("endDate") LocalDateTime endDate);
 }

--- a/src/main/java/com/example/temp/baseball/domain/GameRepository.java
+++ b/src/main/java/com/example/temp/baseball/domain/GameRepository.java
@@ -11,7 +11,11 @@ import java.util.List;
 import java.util.Optional;
 
 public interface GameRepository extends Repository<Game, Long> {
-    @Query("SELECT g FROM Game g WHERE g.season = :season AND (g.homeTeam = :team OR g.awayTeam = :team) AND g.startDate >= :startOfWeek AND g.startDate < :endOfWeek")
+    @Query("SELECT g " +
+            "FROM Game g " +
+            "WHERE g.season = :season " +
+            "   AND (:team IS NULL OR g.homeTeam = :team OR g.awayTeam = :team) " +
+            "   AND g.startDate >= :startOfWeek AND g.startDate < :endOfWeek")
     List<Game> findAllByTeamAndCurrentWeekInYear(@Param("season") Season season,
                                                  @Param("team") Team team,
                                                  @Param("startOfWeek") LocalDateTime startOfWeek,

--- a/src/main/java/com/example/temp/baseball/service/CountFanpoolRelatedFanpoolService.java
+++ b/src/main/java/com/example/temp/baseball/service/CountFanpoolRelatedFanpoolService.java
@@ -1,0 +1,5 @@
+package com.example.temp.baseball.service;
+
+public interface CountFanpoolRelatedFanpoolService {
+    long doService(long gameId);
+}

--- a/src/main/java/com/example/temp/baseball/service/impl/CountFanpoolRelatedFanpoolServiceImpl.java
+++ b/src/main/java/com/example/temp/baseball/service/impl/CountFanpoolRelatedFanpoolServiceImpl.java
@@ -1,0 +1,19 @@
+package com.example.temp.baseball.service.impl;
+
+import com.example.temp.baseball.service.CountFanpoolRelatedFanpoolService;
+import com.example.temp.fanpool.domain.FanpoolRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CountFanpoolRelatedFanpoolServiceImpl implements CountFanpoolRelatedFanpoolService {
+    private final FanpoolRepository fanpoolRepository;
+
+    @Override
+    public long doService(long gameId) {
+        return fanpoolRepository.countByGame(gameId);
+    }
+}

--- a/src/main/java/com/example/temp/baseball/service/impl/FindAllSchedulesDuringThisWeekServiceImpl.java
+++ b/src/main/java/com/example/temp/baseball/service/impl/FindAllSchedulesDuringThisWeekServiceImpl.java
@@ -6,10 +6,8 @@ import com.example.temp.baseball.service.FindAllSchedulesDuringThisWeekService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 
 @Service
@@ -23,8 +21,8 @@ public class FindAllSchedulesDuringThisWeekServiceImpl implements FindAllSchedul
         Season season = seasonRepository.findByYearOrElseThrow(year);
 
         LocalDate now = LocalDate.now();
-        LocalDate startOfWeek = now.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
-        LocalDate endOfWeek = startOfWeek.plusDays(7); // 다음 주 일요일 (exclusive)
+        LocalDate startOfWeek = now.minusDays(1);
+        LocalDate endOfWeek = startOfWeek.plusDays(7);
 
         LocalDateTime startOfWeekDateTime = startOfWeek.atStartOfDay();
         LocalDateTime endOfWeekDateTime = endOfWeek.atStartOfDay();

--- a/src/main/java/com/example/temp/baseball/service/impl/FindGamesByTeamServiceImpl.java
+++ b/src/main/java/com/example/temp/baseball/service/impl/FindGamesByTeamServiceImpl.java
@@ -23,13 +23,8 @@ public class FindGamesByTeamServiceImpl implements FindGamesByTeamService {
     @Transactional(readOnly = true)
     public FindGamesByTeamResponse doService(FindGamesByTeamCommand command) {
         Team team = teamRepository.findByIdOrElseThrow(command.teamId());
-        List<Game> games;
+        List<Game> games = gameRepository.findByTeamOrDateOrderByStartDate(team, command.startDate(), command.endDate());
 
-        if (command.startDate() == null) {
-            games = gameRepository.findByTeamOrderByStartDate(team);
-        } else {
-            games = gameRepository.findByTeamAndDateOrderByStartDate(team, command.startDate(), command.endDate());
-        }
         return FindGamesByTeamResponse.build(games);
     }
 }

--- a/src/main/java/com/example/temp/fanpool/domain/FanpoolRepository.java
+++ b/src/main/java/com/example/temp/fanpool/domain/FanpoolRepository.java
@@ -29,4 +29,10 @@ public interface FanpoolRepository extends Repository<Fanpool, Long> {
 
     @Query("SELECT COUNT(f) FROM Fanpool f WHERE f.hostUser.id = :userId")
     Long countByUserId(@Param("userId") Long userId);
+
+    @Query("SELECT COUNT(f) " +
+            "FROM Fanpool f " +
+            "WHERE f.game.id = :gameId" +
+            "   AND f.state = 'GATHER' ")
+    Long countByGame(@Param("gameId") Long gameId);
 }


### PR DESCRIPTION
- 오늘-1일 ~ 오늘+6일 일주일의 경기 정보 & 응원팀 설정 여부에 따라 달라지도록 수정
- 응원팀 별, 기간 별 조합된 야구 경기 정보
- 경기를 포함하는 팬풀의 개수를 세는 기능