### PR TITLE
회원이 등록한 팬풀로그 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/example/temp/tour/controller/TourController.java
+++ b/src/main/java/com/example/temp/tour/controller/TourController.java
@@ -26,6 +26,7 @@ public class TourController {
     private final FindTourLogBookmarkIdService findTourLogBookmarkIdService;
     private final FindAllTourLogStadiumService findAllTourLogStadiumService;
     private final DeleteTourLogBookmarkService deleteTourLogBookmarkService;
+    private final FindTourLogListByUserService findTourLogListByUserService;
     private final RegisterTourLogBookmarkService registerTourLogBookmarkService;
     private final FindTourLogListByTourPlaceService findTourLogListByTourPlaceService;
     private final FindTourInformationByLocationService findTourInformationByLocationService;
@@ -114,6 +115,16 @@ public class TourController {
             @RequestParam(name = "contentTypeId") Integer contentTypeId
     ) {
         List<TourLogPreview> response = findTourLogListByTourPlaceService.doService(contentId, contentTypeId);
+        return ResponseEntity.ok(new FindTourLogListResponse(response));
+    }
+
+    @GetMapping("/log/find-by-user/{userId}")
+    public ResponseEntity<FindTourLogListResponse> findTourLogListByUser(
+            @PathVariable(name = "userId") Long userId,
+            @RequestParam(name = "lastId", defaultValue = "" + Long.MAX_VALUE) Long lastTourLogId,
+            @RequestParam(name = "pageSize", defaultValue = "6") Integer pageSize
+    ) {
+        List<TourLogPreview> response = findTourLogListByUserService.doService(userId, lastTourLogId, pageSize);
         return ResponseEntity.ok(new FindTourLogListResponse(response));
     }
 

--- a/src/main/java/com/example/temp/tour/domain/TourLogRepository.java
+++ b/src/main/java/com/example/temp/tour/domain/TourLogRepository.java
@@ -77,6 +77,17 @@ public interface TourLogRepository extends Repository<TourLog, Long> {
     )
     List<TourLogPreviewNativeDto> findByTourPlace(@Param("contentId") int contentId, @Param("contentTypeId") int contentTypeId);
 
+    @Query(
+            nativeQuery = true, value = "SELECT t.id as id, t.image_url as image, t.title as title, u.nickname as userNickname, u.profile_image_url as userProfileImage, s.shorten_name as stadiumName " +
+            "FROM tour_log t " +
+            "JOIN user u ON t.user_id = u.id " +
+            "JOIN tour_log_stadium s ON t.stadium_id = s.id " +
+            "WHERE t.user_id = :userId AND t.id < :lastId " +
+            "ORDER BY t.id DESC " +
+            "LIMIT :pageSize"
+    )
+    List<TourLogPreviewNativeDto> findByUser(@Param("userId") long userId, @Param("lastId") long lastTourLogId, @Param("pageSize") int pageSize);
+
     @Query("SELECT COUNT(t) FROM TourLog t WHERE t.user.id = :userId")
     Long countByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/temp/tour/service/FindTourLogListByUserService.java
+++ b/src/main/java/com/example/temp/tour/service/FindTourLogListByUserService.java
@@ -1,0 +1,10 @@
+package com.example.temp.tour.service;
+
+import com.example.temp.tour.dto.TourLogPreview;
+
+import java.util.List;
+
+public interface FindTourLogListByUserService {
+
+    List<TourLogPreview> doService(long userId, long lastTourLogId, int pageSize);
+}

--- a/src/main/java/com/example/temp/tour/service/impl/FindTourLogListByUserServiceImpl.java
+++ b/src/main/java/com/example/temp/tour/service/impl/FindTourLogListByUserServiceImpl.java
@@ -1,0 +1,24 @@
+package com.example.temp.tour.service.impl;
+
+import com.example.temp.tour.domain.TourLogRepository;
+import com.example.temp.tour.dto.TourLogPreview;
+import com.example.temp.tour.service.FindTourLogListByUserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FindTourLogListByUserServiceImpl implements FindTourLogListByUserService {
+
+    private final TourLogRepository tourLogRepository;
+
+    @Override
+    public List<TourLogPreview> doService(long userId, long lastTourLogId, int pageSize) {
+        return tourLogRepository.findByUser(userId, lastTourLogId, pageSize)
+                .stream()
+                .map(TourLogPreview::build)
+                .toList();
+    }
+}


### PR DESCRIPTION
## 작업 내용
- close #62 
- 회원이 등록한 팬풀로그 목록 조회 API 구현
- 페이지네이션 적용
---

## API
### 요청
GET `/log/find-by-user/{userId}?lastId={lastId}&pageSize={pageSize}`
  - `userId` : 회원 id (Path Variable, 필수 o)
  - `lastId` : 마지막으로 조회된 팬풀로그 id (첫 페이지 조회 시 생략, 필수 x)
  - `pageSize` : 페이지 크기 (기본값 : 6, 필수 x)

### 응답 예시
``` JSON
{
    "items": [
        {
            "id": "627137944726311274",
            "image": "",
            "title": "제목",
            "stadium": "대전",
            "profile": {
                "nickname": "동철이",
                "image": "https://csct3434.org"
            }
        }
    ]
}
```

- 팬풀로그 목록 조회 API와 동일