### PR TITLE
팬풀로그 목록 조회 응답 속성 추가 - 장소 미리보기

### DIFF
--- a/src/main/java/com/example/temp/tour/domain/TourLogBookmarkRepository.java
+++ b/src/main/java/com/example/temp/tour/domain/TourLogBookmarkRepository.java
@@ -31,14 +31,20 @@ public interface TourLogBookmarkRepository extends Repository<TourLogBookmark, L
 
     void delete(TourLogBookmark entity);
 
-    @Query(nativeQuery = true, value = "SELECT b.id as bookmarkId, t.id as tourLogId, t.image_url as image, t.title as title, u.nickname as userNickname, u.profile_image_url as userProfileImage, s.shorten_name as stadiumName " +
-            "FROM tour_log_bookmark b " +
-            "JOIN tour_log t on t.id = b.tour_log_id " +
-            "JOIN user u ON t.user_id = u.id " +
-            "JOIN tour_log_stadium s ON t.stadium_id = s.id " +
-            "WHERE b.user_id = :userId AND b.id < :lastId " +
-            "ORDER BY b.id DESC " +
-            "LIMIT :pageSize")
+    @Query(
+            nativeQuery = true,
+            value = "SELECT b.id as bookmarkId, t.id as tourLogId, t.image_url as image, t.title as title, u.nickname as userNickname, u.profile_image_url as userProfileImage, s.shorten_name as stadiumName, " +
+                    "SUBSTRING_INDEX(GROUP_CONCAT(DISTINCT REPLACE(ts.tour_place_name, ' ', '')), ',', 3) AS places " +
+                    "FROM tour_log_bookmark b " +
+                    "JOIN tour_log t on t.id = b.tour_log_id " +
+                    "JOIN user u ON t.user_id = u.id " +
+                    "JOIN tour_log_stadium s ON t.stadium_id = s.id " +
+                    "LEFT JOIN tour_schedule ts ON ts.tour_log_id = t.id " +
+                    "WHERE b.user_id = :userId AND b.id < :lastId " +
+                    "GROUP BY b.id " + // b.id를 기준으로 그룹화하여 각 북마크에 대한 places를 계산
+                    "ORDER BY b.id DESC " +
+                    "LIMIT :pageSize"
+    )
     List<BookmarkedTourLogPreviewNativeDto> findUserBookmarkedTourLogPreviewList(
             @Param("userId") Long userId,
             @Param("lastId") Long lastBookmarkId,

--- a/src/main/java/com/example/temp/tour/domain/TourLogRepository.java
+++ b/src/main/java/com/example/temp/tour/domain/TourLogRepository.java
@@ -28,63 +28,78 @@ public interface TourLogRepository extends Repository<TourLog, Long> {
     // TourScheduleMemo - TourScheduleMemoImage 간에 N+1 문제를 해결하고자 Batch Size 설정
     @Query(
             "SELECT t FROM TourLog t " +
-            "LEFT JOIN FETCH t.schedules ts " +
-            "LEFT JOIN FETCH ts.tourPlace tp " +
-            "LEFT JOIN FETCH ts.memo tsm " +
-            "WHERE t.id = :id"
+                    "LEFT JOIN FETCH t.schedules ts " +
+                    "LEFT JOIN FETCH ts.tourPlace tp " +
+                    "LEFT JOIN FETCH ts.memo tsm " +
+                    "WHERE t.id = :id"
     )
     Optional<TourLog> findByIdWithAllAssociationsForUpdate(@Param("id") Long id);
 
     @Query(
             "SELECT t FROM TourLog t " +
-            "JOIN FETCH t.user u " +
-            "JOIN FETCH t.stadium s " +
-            "LEFT JOIN FETCH t.schedules ts " +
-            "LEFT JOIN FETCH ts.tourPlace tp " +
-            "LEFT JOIN FETCH ts.memo tsm " +
-            "WHERE t.id = :id"
+                    "JOIN FETCH t.user u " +
+                    "JOIN FETCH t.stadium s " +
+                    "LEFT JOIN FETCH t.schedules ts " +
+                    "LEFT JOIN FETCH ts.tourPlace tp " +
+                    "LEFT JOIN FETCH ts.memo tsm " +
+                    "WHERE t.id = :id"
     )
     Optional<TourLog> findByIdWithAllAssociationsForRead(@Param("id") Long id);
 
     @Query(
-            nativeQuery = true, value = "SELECT t.id as id, t.image_url as image, t.title as title, u.nickname as userNickname, u.profile_image_url as userProfileImage, s.shorten_name as stadiumName " +
-            "FROM tour_log t " +
-            "JOIN user u ON t.user_id = u.id " +
-            "JOIN tour_log_stadium s ON t.stadium_id = s.id " +
-            "WHERE t.id < :lastId " +
-            "ORDER BY t.id DESC " +
-            "LIMIT :pageSize"
+            nativeQuery = true,
+            value = "SELECT t.id as id, t.image_url as image, t.title as title, u.nickname as userNickname, u.profile_image_url as userProfileImage, s.shorten_name as stadiumName, " +
+                    "SUBSTRING_INDEX(GROUP_CONCAT(DISTINCT REPLACE(ts.tour_place_name, ' ', '')), ',', 3) AS places " +
+                    "FROM tour_log t " +
+                    "JOIN user u ON t.user_id = u.id " +
+                    "JOIN tour_log_stadium s ON t.stadium_id = s.id " +
+                    "LEFT JOIN tour_schedule ts ON ts.tour_log_id = t.id " +
+                    "WHERE t.id < :lastId " +
+                    "GROUP BY t.id " +
+                    "ORDER BY t.id DESC " +
+                    "LIMIT :pageSize"
     )
     List<TourLogPreviewNativeDto> findRecentTourLogList(@Param("lastId") long lastTourLogId, @Param("pageSize") int pageSize);
 
     @Query(
-            nativeQuery = true, value = "SELECT t.id as id, t.image_url as image, t.title as title, u.nickname as userNickname, u.profile_image_url as userProfileImage, s.shorten_name as stadiumName " +
-            "FROM tour_log t " +
-            "JOIN user u ON t.user_id = u.id " +
-            "JOIN tour_log_stadium s ON t.stadium_id = s.id " +
-            "WHERE t.id < :lastId AND t.stadium_id = :stadiumId " +
-            "ORDER BY t.id DESC " +
-            "LIMIT :pageSize"
+            nativeQuery = true,
+            value = "SELECT t.id as id, t.image_url as image, t.title as title, u.nickname as userNickname, u.profile_image_url as userProfileImage, s.shorten_name as stadiumName, " +
+                    "SUBSTRING_INDEX(GROUP_CONCAT(DISTINCT REPLACE(ts.tour_place_name, ' ', '')), ',', 3) AS places " +
+                    "FROM tour_log t " +
+                    "JOIN user u ON t.user_id = u.id " +
+                    "JOIN tour_log_stadium s ON t.stadium_id = s.id " +
+                    "LEFT JOIN tour_schedule ts ON ts.tour_log_id = t.id " +
+                    "WHERE t.id < :lastId AND t.stadium_id = :stadiumId " +
+                    "GROUP BY t.id " +
+                    "ORDER BY t.id DESC " +
+                    "LIMIT :pageSize"
     )
     List<TourLogPreviewNativeDto> findRecentTourLogListByStadium(@Param("stadiumId") long stadiumId, @Param("lastId") long lastTourLogId, @Param("pageSize") int pageSize);
 
     @Query(
-            nativeQuery = true, value = "SELECT t.id as id, t.image_url as image, t.title as title, u.nickname as userNickname, u.profile_image_url as userProfileImage, s.shorten_name as stadiumName " +
-            "FROM tour_log t " +
-            "JOIN user u ON t.user_id = u.id " +
-            "JOIN tour_log_stadium s ON t.stadium_id = s.id " +
-            "WHERE t.id IN (SELECT * FROM (SELECT ts.tour_log_id FROM tour_schedule ts WHERE ts.tour_place_id = (SELECT tp.id FROM tour_place tp WHERE tp.content_id = :contentId AND tp.content_type_id = :contentTypeId) ORDER BY ts.id DESC LIMIT 5) as temp)"
+            nativeQuery = true,
+            value = "SELECT t.id as id, t.image_url as image, t.title as title, u.nickname as userNickname, u.profile_image_url as userProfileImage, s.shorten_name as stadiumName, '' AS places " +
+                    "FROM tour_log t " +
+                    "JOIN user u ON t.user_id = u.id " +
+                    "JOIN tour_log_stadium s ON t.stadium_id = s.id " +
+                    "LEFT JOIN tour_schedule ts ON ts.tour_log_id = t.id AND ts.tour_place_content_id = :contentId AND ts.tour_place_content_type_id = :contentTypeId " +
+                    "ORDER BY ts.id DESC " +
+                    "LIMIT 5;"
     )
     List<TourLogPreviewNativeDto> findByTourPlace(@Param("contentId") int contentId, @Param("contentTypeId") int contentTypeId);
 
     @Query(
-            nativeQuery = true, value = "SELECT t.id as id, t.image_url as image, t.title as title, u.nickname as userNickname, u.profile_image_url as userProfileImage, s.shorten_name as stadiumName " +
-            "FROM tour_log t " +
-            "JOIN user u ON t.user_id = u.id " +
-            "JOIN tour_log_stadium s ON t.stadium_id = s.id " +
-            "WHERE t.user_id = :userId AND t.id < :lastId " +
-            "ORDER BY t.id DESC " +
-            "LIMIT :pageSize"
+            nativeQuery = true,
+            value = "SELECT t.id as id, t.image_url as image, t.title as title, u.nickname as userNickname, u.profile_image_url as userProfileImage, s.shorten_name as stadiumName, " +
+                    "SUBSTRING_INDEX(GROUP_CONCAT(DISTINCT REPLACE(ts.tour_place_name, ' ', '')), ',', 3) AS places " +
+                    "FROM tour_log t " +
+                    "JOIN user u ON t.user_id = u.id " +
+                    "JOIN tour_log_stadium s ON t.stadium_id = s.id " +
+                    "LEFT JOIN tour_schedule ts ON ts.tour_log_id = t.id " +
+                    "WHERE t.user_id = :userId AND t.id < :lastId " +
+                    "GROUP BY t.id " +
+                    "ORDER BY t.id DESC " +
+                    "LIMIT :pageSize"
     )
     List<TourLogPreviewNativeDto> findByUser(@Param("userId") long userId, @Param("lastId") long lastTourLogId, @Param("pageSize") int pageSize);
 

--- a/src/main/java/com/example/temp/tour/domain/TourSchedule.java
+++ b/src/main/java/com/example/temp/tour/domain/TourSchedule.java
@@ -33,6 +33,12 @@ public class TourSchedule extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private TourPlace tourPlace;
 
+    private String tourPlaceName;
+
+    private Integer tourPlaceContentId;
+
+    private Integer tourPlaceContentTypeId;
+
     @Setter
     @OneToOne(mappedBy = "tourSchedule", fetch = FetchType.LAZY, orphanRemoval = true, cascade = CascadeType.ALL)
     private TourScheduleMemo memo;
@@ -44,5 +50,8 @@ public class TourSchedule extends BaseTimeEntity {
         this.day = day;
         this.sequence = sequence;
         this.tourPlace = tourPlace;
+        this.tourPlaceName = tourPlace.getName();
+        this.tourPlaceContentId = tourPlace.getContentId();
+        this.tourPlaceContentTypeId = tourPlace.getContentTypeId();
     }
 }

--- a/src/main/java/com/example/temp/tour/dto/BookmarkedTourLogPreview.java
+++ b/src/main/java/com/example/temp/tour/dto/BookmarkedTourLogPreview.java
@@ -10,7 +10,9 @@ public record BookmarkedTourLogPreview(
                 vo.getImage(),
                 vo.getTitle(),
                 vo.getStadiumName(),
-                new UserProfileView(vo.getUserNickname(), vo.getUserProfileImage()));
+                new UserProfileView(vo.getUserNickname(), vo.getUserProfileImage()),
+                vo.getPlaces()
+        );
 
         return new BookmarkedTourLogPreview(vo.getBookmarkId(), tourLogPreview);
     }

--- a/src/main/java/com/example/temp/tour/dto/BookmarkedTourLogPreviewNativeDto.java
+++ b/src/main/java/com/example/temp/tour/dto/BookmarkedTourLogPreviewNativeDto.java
@@ -15,4 +15,6 @@ public interface BookmarkedTourLogPreviewNativeDto {
     String getUserProfileImage();
 
     String getStadiumName();
+
+    String getPlaces();
 }

--- a/src/main/java/com/example/temp/tour/dto/TourLogPreview.java
+++ b/src/main/java/com/example/temp/tour/dto/TourLogPreview.java
@@ -5,7 +5,8 @@ public record TourLogPreview(
         String image,
         String title,
         String stadium,
-        UserProfileView profile
+        UserProfileView profile,
+        String places
 ) {
 
     public static TourLogPreview build(TourLogPreviewNativeDto vo) {
@@ -14,6 +15,8 @@ public record TourLogPreview(
                 vo.getImage(),
                 vo.getTitle(),
                 vo.getStadiumName(),
-                new UserProfileView(vo.getUserNickname(), vo.getUserProfileImage()));
+                new UserProfileView(vo.getUserNickname(), vo.getUserProfileImage()),
+                vo.getPlaces()
+        );
     }
 }

--- a/src/main/java/com/example/temp/tour/dto/TourLogPreviewNativeDto.java
+++ b/src/main/java/com/example/temp/tour/dto/TourLogPreviewNativeDto.java
@@ -13,4 +13,6 @@ public interface TourLogPreviewNativeDto {
     String getUserProfileImage();
 
     String getStadiumName();
+
+    String getPlaces();
 }


### PR DESCRIPTION
## 작업 내용
- close #63
- 조회 성능 향상을 위해 TourSchedule과 TourPlace 사이 역정규화 일부 적용
- 장소별 조회의 경우 쿼리문이 복잡해져서 장소 미리보기 제공 안하는 것으로 결정 (항상 빈 문자열로 응답)

## 프론트 참고사항
``` JSON
{
          "id": "627102801673041306",
          "image": "",
          "title": "테스트",
          "stadium": "대전",
          "profile": {
              "nickname": "동철이",
              "image": "https://csct3434.org"
          },
          "places": "길거리음식인천리미닛집,수호식당,인천광장"
}
```
- 각종 팬풀로그 목록 조회 API(최신순, 경기장별, 회원별, 장소별, 북마크)에 places 속성 추가 
- 방문 장소 중 3개까지만 응답
- 장소별 조회(`GET /tour/log/find-by-place`)의 경우 places는 항상 빈 문자열("")로 응답합니다