### PR TITLE
JPA 영속성 관련 문제

### DIFF
--- a/src/main/java/com/example/temp/baseball/controller/BaseballGameController.java
+++ b/src/main/java/com/example/temp/baseball/controller/BaseballGameController.java
@@ -11,6 +11,7 @@ import com.example.temp.baseball.service.FindGamesByTeamService;
 import com.example.temp.common.dto.IdResponse;
 import com.example.temp.common.entity.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -32,8 +33,12 @@ public class BaseballGameController {
     public ResponseEntity<FindGamesByTeamResponse> findByTeam(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestParam(value = "teamId", required = false) String teamId,
-            @RequestParam(value = "startDate", required = false) LocalDateTime startDate,
-            @RequestParam(value = "endDate", required = false) LocalDateTime endDate
+
+            @RequestParam(value = "startDate", required = false)
+            @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime startDate,
+
+            @RequestParam(value = "endDate", required = false)
+            @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime endDate
     ) {
         FindGamesByTeamCommand command = new FindGamesByTeamCommand(Long.parseLong(teamId), startDate, endDate);
         FindGamesByTeamResponse result = findGamesByTeamService.doService(command);

--- a/src/main/java/com/example/temp/baseball/dto/UpdatedUserProfileCommand.java
+++ b/src/main/java/com/example/temp/baseball/dto/UpdatedUserProfileCommand.java
@@ -15,8 +15,8 @@ public record UpdatedUserProfileCommand(
                 id,
                 userProfile.getNickname(),
                 Long.parseLong(userProfile.getFavoriteTeam()),
-                userProfile.getOneLiner(),
-                userProfile.getProfileImageUrl()
+                userProfile.getProfileImageUrl(),
+                userProfile.getOneLiner()
         );
     }
 }

--- a/src/main/java/com/example/temp/baseball/service/impl/FindAllSchedulesDuringThisWeekServiceImpl.java
+++ b/src/main/java/com/example/temp/baseball/service/impl/FindAllSchedulesDuringThisWeekServiceImpl.java
@@ -5,6 +5,7 @@ import com.example.temp.baseball.dto.GameScheduleResponse;
 import com.example.temp.baseball.service.FindAllSchedulesDuringThisWeekService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -17,6 +18,7 @@ public class FindAllSchedulesDuringThisWeekServiceImpl implements FindAllSchedul
     private final SeasonRepository seasonRepository;
 
     @Override
+    @Transactional(readOnly = true)
     public GameScheduleResponse doService(Team team, int year) {
         Season season = seasonRepository.findByYearOrElseThrow(year);
 

--- a/src/main/java/com/example/temp/baseball/service/impl/FindAllTeamsInSeasonServiceImpl.java
+++ b/src/main/java/com/example/temp/baseball/service/impl/FindAllTeamsInSeasonServiceImpl.java
@@ -8,6 +8,7 @@ import com.example.temp.baseball.dto.TeamView;
 import com.example.temp.baseball.service.FindAllTeamsInSeasonService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -19,6 +20,7 @@ public class FindAllTeamsInSeasonServiceImpl implements FindAllTeamsInSeasonServ
     private final SeasonRepository seasonRepository;
 
     @Override
+    @Transactional(readOnly = true)
     public List<TeamView> doService(int year) {
         Optional<Season> found = seasonRepository.findByYear(year);
         if (found.isEmpty()) {

--- a/src/main/java/com/example/temp/fanpool/controller/FanpoolController.java
+++ b/src/main/java/com/example/temp/fanpool/controller/FanpoolController.java
@@ -7,6 +7,7 @@ import com.example.temp.fanpool.service.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -55,8 +56,10 @@ public class FanpoolController {
             @RequestParam(value = "teamId", required = false) long teamId,
             @RequestParam(value = "dongCd", required = false) String dongCd,
             @RequestParam(value = "gameId", required = false) List<Long> gameId,
-            @RequestParam(value = "departAt", required = false) LocalDateTime departAt,
-            @RequestParam(value = "onlyGathering", required = true) boolean onlyGathering
+            @RequestParam(value = "onlyGathering", required = true) boolean onlyGathering,
+
+            @RequestParam(value = "departAt", required = false)
+            @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime departAt
     ) {
         FindFilteredFanpoolCommand command = new FindFilteredFanpoolCommand(teamId, dongCd, gameId, departAt, onlyGathering, pageable);
         FindFilteredFanpoolResponse result = findFilteredFanpoolService.doService(command);

--- a/src/main/java/com/example/temp/fanpool/service/impl/FindFanpoolByIdServiceImpl.java
+++ b/src/main/java/com/example/temp/fanpool/service/impl/FindFanpoolByIdServiceImpl.java
@@ -6,6 +6,7 @@ import com.example.temp.fanpool.dto.FindFanpoolBasedLocationResponse;
 import com.example.temp.fanpool.service.FindFanpoolByIdService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -13,6 +14,7 @@ public class FindFanpoolByIdServiceImpl implements FindFanpoolByIdService {
     private final FanpoolRepository fanpoolRepository;
 
     @Override
+    @Transactional(readOnly = true)
     public FindFanpoolBasedLocationResponse doService(long id) {
         Fanpool found = fanpoolRepository.findByIdOrElseThrow(id);
         return FindFanpoolBasedLocationResponse.build(found);

--- a/src/main/java/com/example/temp/fanpool/service/impl/FindFilteredFanpoolServiceImpl.java
+++ b/src/main/java/com/example/temp/fanpool/service/impl/FindFilteredFanpoolServiceImpl.java
@@ -10,6 +10,7 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -19,6 +20,7 @@ public class FindFilteredFanpoolServiceImpl implements FindFilteredFanpoolServic
     private final JPAQueryFactory queryFactory;
 
     @Override
+    @Transactional(readOnly = true)
     public FindFilteredFanpoolResponse doService(FindFilteredFanpoolCommand command) {
         QFanpool fanpool = QFanpool.fanpool;
         BooleanBuilder builder = new BooleanBuilder();

--- a/src/main/java/com/example/temp/fanpool/service/impl/FindLatestFanpoolServiceImpl.java
+++ b/src/main/java/com/example/temp/fanpool/service/impl/FindLatestFanpoolServiceImpl.java
@@ -11,6 +11,7 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -23,6 +24,7 @@ public class FindLatestFanpoolServiceImpl implements FindLatestFanpoolService {
     private final JPAQueryFactory queryFactory;
 
     @Override
+    @Transactional(readOnly = true)
     public FindLatestFanpoolResponse doService(long userId) {
         User user = userRepository.findByIdOrElseThrow(userId);
         Team favoriteTeam = user.getFavoriteTeam();


### PR DESCRIPTION
QueryDSL을 사용하지 않는 서비스에서도 could not initialize proxy - no Session 문제 발생, DSL에 join()을 추가했지만 같은 문제 발생, 근데 로컬에선 돌아간다?!?!?

@Transactional(readOnly = true) 추가 : 유일하게 세션문제가 발생하지 않는 팬풀조회 API가 @Transactional 어노테이션을 갖고 있어서 추가해봄