### PR TITLE
회원 탈퇴 기능

### DIFF
--- a/src/main/java/com/example/temp/fanpool/controller/FanpoolController.java
+++ b/src/main/java/com/example/temp/fanpool/controller/FanpoolController.java
@@ -66,7 +66,8 @@ public class FanpoolController {
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @PathVariable("fanpoolId") String fanpoolId
     ) {
-        FindFanpoolBasedLocationResponse result = findFanpoolByIdService.doService(Long.parseLong(fanpoolId));
+        FindFanpoolBasedLocationResponse result = findFanpoolByIdService
+                .doService(Long.parseLong(fanpoolId), customUserDetails.getId());
         return ResponseEntity.ok(result);
     }
 

--- a/src/main/java/com/example/temp/fanpool/controller/FanpoolController.java
+++ b/src/main/java/com/example/temp/fanpool/controller/FanpoolController.java
@@ -7,13 +7,11 @@ import com.example.temp.fanpool.service.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
@@ -56,12 +54,9 @@ public class FanpoolController {
             @RequestParam(value = "teamId", required = false) Long teamId,
             @RequestParam(value = "dongCd", required = false) String dongCd,
             @RequestParam(value = "gameId", required = false) List<Long> gameId,
-            @RequestParam(value = "onlyGathering", required = true) boolean onlyGathering,
-
-            @RequestParam(value = "departAt", required = false)
-            @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime departAt
+            @RequestParam(value = "onlyGathering", required = true) boolean onlyGathering
     ) {
-        FindFilteredFanpoolCommand command = new FindFilteredFanpoolCommand(teamId, dongCd, gameId, departAt, onlyGathering, pageable);
+        FindFilteredFanpoolCommand command = new FindFilteredFanpoolCommand(teamId, dongCd, gameId, onlyGathering, pageable);
         FindFilteredFanpoolResponse result = findFilteredFanpoolService.doService(command);
         return ResponseEntity.ok(result);
     }

--- a/src/main/java/com/example/temp/fanpool/dto/FanpoolView.java
+++ b/src/main/java/com/example/temp/fanpool/dto/FanpoolView.java
@@ -19,7 +19,8 @@ public record FanpoolView(
         String genderConstraint,
         int numberOfPeople,
         int currentNumberOfPeople,
-        String memo
+        String memo,
+        String state
 ) {
     public FanpoolView(Fanpool fanpool) {
         this(
@@ -34,7 +35,8 @@ public record FanpoolView(
                 fanpool.getGenderConstraint().getKor(),
                 fanpool.getNumberOfPeople(),
                 fanpool.getCurrentNumberOfPeople(),
-                fanpool.getMemo()
+                fanpool.getMemo(),
+                fanpool.getState().toString()
         );
     }
 }

--- a/src/main/java/com/example/temp/fanpool/dto/FindFanpoolBasedLocationResponse.java
+++ b/src/main/java/com/example/temp/fanpool/dto/FindFanpoolBasedLocationResponse.java
@@ -6,10 +6,12 @@ import lombok.Getter;
 @Getter
 public class FindFanpoolBasedLocationResponse {
     private FanpoolView fanpoolInformation;
+    private boolean hosted;
 
-    public static FindFanpoolBasedLocationResponse build(Fanpool fanpool) {
+    public static FindFanpoolBasedLocationResponse build(Fanpool fanpool, long userId) {
         FindFanpoolBasedLocationResponse ret = new FindFanpoolBasedLocationResponse();
         ret.fanpoolInformation = new FanpoolView(fanpool);
+        ret.hosted = !fanpool.isNotHostUser(userId);         // 내가 주최한 팬풀인지 확인
         return ret;
     }
 }

--- a/src/main/java/com/example/temp/fanpool/dto/command/FindFilteredFanpoolCommand.java
+++ b/src/main/java/com/example/temp/fanpool/dto/command/FindFilteredFanpoolCommand.java
@@ -2,14 +2,12 @@ package com.example.temp.fanpool.dto.command;
 
 import org.springframework.data.domain.Pageable;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 public record FindFilteredFanpoolCommand(
         Long teamId,
         String dongCd,
         List<Long> gameId,
-        LocalDateTime departAt,
         boolean onlyGathering,
         Pageable pageable
 ) {

--- a/src/main/java/com/example/temp/fanpool/service/FindFanpoolByIdService.java
+++ b/src/main/java/com/example/temp/fanpool/service/FindFanpoolByIdService.java
@@ -3,5 +3,5 @@ package com.example.temp.fanpool.service;
 import com.example.temp.fanpool.dto.FindFanpoolBasedLocationResponse;
 
 public interface FindFanpoolByIdService {
-    FindFanpoolBasedLocationResponse doService(long id);
+    FindFanpoolBasedLocationResponse doService(long id, long userId);
 }

--- a/src/main/java/com/example/temp/fanpool/service/impl/FindFanpoolByIdServiceImpl.java
+++ b/src/main/java/com/example/temp/fanpool/service/impl/FindFanpoolByIdServiceImpl.java
@@ -2,6 +2,7 @@ package com.example.temp.fanpool.service.impl;
 
 import com.example.temp.fanpool.domain.Fanpool;
 import com.example.temp.fanpool.domain.FanpoolRepository;
+import com.example.temp.fanpool.domain.FanpoolUserRepository;
 import com.example.temp.fanpool.dto.FindFanpoolBasedLocationResponse;
 import com.example.temp.fanpool.service.FindFanpoolByIdService;
 import lombok.RequiredArgsConstructor;
@@ -15,8 +16,8 @@ public class FindFanpoolByIdServiceImpl implements FindFanpoolByIdService {
 
     @Override
     @Transactional(readOnly = true)
-    public FindFanpoolBasedLocationResponse doService(long id) {
+    public FindFanpoolBasedLocationResponse doService(long id, long userId) {
         Fanpool found = fanpoolRepository.findByIdOrElseThrow(id);
-        return FindFanpoolBasedLocationResponse.build(found);
+        return FindFanpoolBasedLocationResponse.build(found, userId);
     }
 }

--- a/src/main/java/com/example/temp/fanpool/service/impl/FindFilteredFanpoolServiceImpl.java
+++ b/src/main/java/com/example/temp/fanpool/service/impl/FindFilteredFanpoolServiceImpl.java
@@ -28,13 +28,6 @@ public class FindFilteredFanpoolServiceImpl implements FindFilteredFanpoolServic
         if (command.gameId() != null && !command.gameId().isEmpty()) {
             builder.and(fanpool.game.id.in(command.gameId()));
         }
-        if (command.departAt() != null) {
-            builder.and(
-                    fanpool.departAt.year().eq(command.departAt().getYear())
-                            .and(fanpool.departAt.month().eq(command.departAt().getMonthValue()))
-                            .and(fanpool.departAt.dayOfMonth().eq(command.departAt().getDayOfMonth()))
-            );
-        }
         if (command.teamId() != null) {
             builder.and(
                     (fanpool.game.awayTeam.id.eq(command.teamId()))

--- a/src/main/java/com/example/temp/user/controller/UserController.java
+++ b/src/main/java/com/example/temp/user/controller/UserController.java
@@ -26,7 +26,15 @@ public class UserController {
     private final DeleteUserBlockingService deleteUserBlockingService;
     private final FindUserAuthenticatedLocationService findUserAuthenticatedLocationService;
     private final UpdateUserAuthenticatedLocationService updateUserAuthenticatedLocationService;
+    private final DeleteUserService deleteUserService;
 
+    @DeleteMapping()
+    public ResponseEntity<Void> delete(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        deleteUserService.doService(userDetails.getId());
+        return ResponseEntity.ok().build();
+    }
 
     @GetMapping("/profile/{targetUserId}")
     public ResponseEntity<UserProfileView> findProfile(
@@ -97,7 +105,6 @@ public class UserController {
         deleteUserBlockingService.doService(command);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
-
 
     @PatchMapping("/location/{locationId}")
     public ResponseEntity<Void> updateAuthenticatedLocation(

--- a/src/main/java/com/example/temp/user/domain/UserRepository.java
+++ b/src/main/java/com/example/temp/user/domain/UserRepository.java
@@ -21,4 +21,5 @@ public interface UserRepository extends Repository<User, Long> {
         return findById(id).orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "회원 조회 실패"));
     }
 
+    void delete(User user);
 }

--- a/src/main/java/com/example/temp/user/service/DeleteUserService.java
+++ b/src/main/java/com/example/temp/user/service/DeleteUserService.java
@@ -1,0 +1,5 @@
+package com.example.temp.user.service;
+
+public interface DeleteUserService {
+    void doService(long id);
+}

--- a/src/main/java/com/example/temp/user/service/impl/DeleteUserServiceImpl.java
+++ b/src/main/java/com/example/temp/user/service/impl/DeleteUserServiceImpl.java
@@ -1,0 +1,21 @@
+package com.example.temp.user.service.impl;
+
+import com.example.temp.user.domain.User;
+import com.example.temp.user.domain.UserRepository;
+import com.example.temp.user.service.DeleteUserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DeleteUserServiceImpl implements DeleteUserService {
+    private final UserRepository userRepository;
+
+    @Override
+    public void doService(long id) {
+        User user = userRepository.findByIdOrElseThrow(id);
+        userRepository.delete(user);
+    }
+}


### PR DESCRIPTION
- 회원 탈퇴 

- 내가 팬풀 주최했는지 여부 기능에 대해서
![image](https://github.com/user-attachments/assets/c302f8f0-2999-4bf0-ab52-a7b0ee4ab3e9)
1. 팬풀 참여하기 누르면 -> FanpoolUser 테이블에 Fanpool과 User를 연관시켜 저장 -> 이후 채팅방으로 넘어가던 기획이었음
2. 기획디자인이 바뀐 걸 오늘 앎, 팬풀 참여가 아닌 채팅하기로 바뀌고 팬풀호스트가 수동으로 참여인원을 조정하는 거로
  ->성준 : 채팅이 완성 안 되면 지금 기획에서 누가 참여하는지 어떻게 확인하느냐?

3-1. 채팅이 완성되면 피그마처럼
3-2. 채팅이 완성 안 되면 API 구현해놓은 대로 참여하기/취소하기 로 버튼 뜨게 하자. 그런데 이제 '내가 참여한 팬풀'을 볼 수 있는 화면이 없는...

etc) 필터링 됩니다