### PR TITLE
채팅방 목록 조회 API 응답에 팬풀 식별자 속성 추가

### DIFF
--- a/src/main/java/com/example/temp/chat/domain/ChatroomRepository.java
+++ b/src/main/java/com/example/temp/chat/domain/ChatroomRepository.java
@@ -23,6 +23,7 @@ public interface ChatroomRepository extends Repository<Chatroom, Long> {
     @Query(
             nativeQuery = true,
             value = "SELECT cr.id as roomId, " +
+                    "       cr.fanpool_id as fanpoolId, " +
                     "       IF(cr.host_user_id = :userId, TRUE, FALSE) AS isHost, " +
                     "       cu.last_activity_time as lastActivityTime, " +
                     "       u.id as partnerId, " +

--- a/src/main/java/com/example/temp/chat/dto/FindChatroomListNativeDto.java
+++ b/src/main/java/com/example/temp/chat/dto/FindChatroomListNativeDto.java
@@ -6,6 +6,8 @@ public interface FindChatroomListNativeDto {
 
     Long getRoomId();
 
+    Long getFanpoolId();
+
     Integer getIsHost();
 
     LocalDateTime getLastActivityTime();

--- a/src/main/java/com/example/temp/chat/dto/FindChatroomListResult.java
+++ b/src/main/java/com/example/temp/chat/dto/FindChatroomListResult.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 
 public record FindChatroomListResult(
         String roomId,
+        String fanpoolId,
         boolean isHost,
         LocalDateTime lastActivityTime,
         UserProfileView partner,
@@ -26,7 +27,8 @@ public record FindChatroomListResult(
         }
 
         return new FindChatroomListResult(
-                dto.getRoomId().toString(),
+                String.valueOf(dto.getRoomId()),
+                String.valueOf(dto.getFanpoolId()),
                 dto.getIsHost() == 1,
                 dto.getLastActivityTime(),
                 partnerProfile,

--- a/src/main/java/com/example/temp/chat/service/impl/FindChatroomListServiceImpl.java
+++ b/src/main/java/com/example/temp/chat/service/impl/FindChatroomListServiceImpl.java
@@ -1,7 +1,8 @@
-package com.example.temp.chat.service;
+package com.example.temp.chat.service.impl;
 
 import com.example.temp.chat.domain.ChatroomRepository;
 import com.example.temp.chat.dto.FindChatroomListResult;
+import com.example.temp.chat.service.FindChatroomListService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;


### PR DESCRIPTION
### 작업 내용
- 채팅방 목록 조회 API 응답에 팬풀 식별자 속성 (fanpoolId) 추가

### 응답 예시
``` json
[
    {
        "roomId": "630751004015391398",
        "fanpoolId": "630751004015391398",
        "isHost": false,
        "lastActivityTime": "2024-10-06T12:59:39.280669",
        "partner": null,
        "teams": "SSG 랜더스 vs KT 위즈",
        "lastMessage": {
            "content": "Hi",
            "time": "2024-10-06T21:59:18.24105"
        }
    }
]
```